### PR TITLE
Improve release folder detection

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,13 +5,15 @@ const fsp = fs.promises;
 
 const app = express();
 const PORT = process.env.PORT || 8080;
+// Allow overriding the releases directory for flexibility
+const releasesDir = process.env.RELEASES_DIR ||
+  path.join(__dirname, 'releases');
 
 // Serve static files from repo root
 app.use(express.static(path.join(__dirname)));
 
 // Detect available releases and return the two most recent
 app.get('/api/releases', async (req, res) => {
-  const releasesDir = path.join(__dirname, 'releases');
   let releaseList = [];
   let current = null;
   let previous = null;
@@ -21,9 +23,19 @@ app.get('/api/releases', async (req, res) => {
     const entries = await fsp.readdir(releasesDir);
     for (const entry of entries) {
       const full = path.join(releasesDir, entry);
-      const stat = await fsp.stat(full);
-      if (stat.isDirectory() && fs.existsSync(path.join(full, 'META'))) {
-        releaseList.push(entry);
+      try {
+        const stat = await fsp.stat(full);
+        if (stat.isDirectory()) {
+          const subEntries = await fsp.readdir(full);
+          const hasMeta = subEntries.some(
+            (d) => d.toLowerCase() === 'meta'
+          );
+          if (hasMeta) {
+            releaseList.push(entry);
+          }
+        }
+      } catch {
+        // ignore unreadable entries
       }
     }
     releaseList.sort().reverse();
@@ -38,4 +50,5 @@ app.get('/api/releases', async (req, res) => {
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
+  console.log(`Using releases directory: ${releasesDir}`);
 });


### PR DESCRIPTION
## Summary
- allow customizing the release folder location with `RELEASES_DIR`
- check META directory case-insensitively and ignore unreadable entries
- log the releases directory on startup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864067178a48327b2bfdbb37da39497