### PR TITLE
Add file size comparison

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -21,3 +21,13 @@ body {
 #summary p {
   margin: 4px 0;
 }
+
+table {
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+th, td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  text-align: left;
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
   <div class="container">
     <h1>UMLS Release QA</h1>
     <div id="status"></div>
+    <button id="compare-sizes">Compare File Sizes</button>
+    <div id="size-results"></div>
   </div>
 
   <script type="module">
@@ -38,6 +40,39 @@
       }
     }
     checkReleases();
+
+    document.getElementById('compare-sizes').addEventListener('click', async () => {
+      const results = document.getElementById('size-results');
+      results.innerHTML = '<p>Comparing...</p>';
+      try {
+        const resp = await fetch('/api/file-size-diff');
+        if (!resp.ok) {
+          results.innerHTML = `<p style="color:red">Failed: ${resp.status}</p>`;
+          return;
+        }
+        const data = await resp.json();
+        const { current, previous, files } = data;
+        if (!files.length) {
+          results.innerHTML = '<p>No files found.</p>';
+          return;
+        }
+        let html = `<h3>File Size Comparison (${current} vs ${previous})</h3>`;
+        html += '<table><thead><tr><th>File</th><th>Previous (bytes)</th><th>Current (bytes)</th><th>Change</th><th>% Change</th></tr></thead><tbody>';
+        for (const f of files) {
+          const prev = f.previous ?? 0;
+          const cur = f.current ?? 0;
+          const diff = cur - prev;
+          const percent = prev ? (diff / prev) * 100 : 0;
+          const highlight = percent > 5 ? ' style="background:#fffa90"' : '';
+          const decrease = diff < 0 ? ' style="color:red"' : '';
+          html += `<tr${highlight}><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td><td${decrease}>${percent.toFixed(2)}%</td></tr>`;
+        }
+        html += '</tbody></table>';
+        results.innerHTML = html;
+      } catch (err) {
+        results.innerHTML = `<p style="color:red">Error: ${err.message}</p>`;
+      }
+    });
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -5,14 +5,15 @@ const fsp = fs.promises;
 
 const app = express();
 const PORT = process.env.PORT || 8080;
+// Allow overriding the releases directory for flexibility
+const releasesDir = process.env.RELEASES_DIR ||
+  path.join(__dirname, 'releases');
 
 // Serve static files from repo root
 app.use(express.static(path.join(__dirname)));
 
-// Detect available releases and return the two most recent
-app.get('/api/releases', async (req, res) => {
-  const releasesDir = path.join(__dirname, 'releases');
-  let releaseList = [];
+async function detectReleases() {
+  const releaseList = [];
   let current = null;
   let previous = null;
 
@@ -21,21 +22,71 @@ app.get('/api/releases', async (req, res) => {
     const entries = await fsp.readdir(releasesDir);
     for (const entry of entries) {
       const full = path.join(releasesDir, entry);
-      const stat = await fsp.stat(full);
-      if (stat.isDirectory() && fs.existsSync(path.join(full, 'META'))) {
-        releaseList.push(entry);
+      try {
+        const stat = await fsp.stat(full);
+        if (stat.isDirectory()) {
+          const subEntries = await fsp.readdir(full);
+          const hasMeta = subEntries.some(
+            (d) => d.toLowerCase() === 'meta'
+          );
+          if (hasMeta) {
+            releaseList.push(entry);
+          }
+        }
+      } catch {
+        // ignore unreadable entries
       }
     }
     releaseList.sort().reverse();
     current = releaseList[0] || null;
     previous = releaseList[1] || null;
-  } catch (err) {
+  } catch {
     // ignore if releasesDir doesn't exist
   }
 
-  res.json({ current, previous, releaseList });
+  return { current, previous, releaseList };
+}
+
+// Detect available releases and return the two most recent
+app.get('/api/releases', async (req, res) => {
+  const result = await detectReleases();
+  res.json(result);
+});
+
+function safeStatSize(file) {
+  return fsp.stat(file).then(s => s.size).catch(() => null);
+}
+
+// Compare file sizes in META between current and previous release
+app.get('/api/file-size-diff', async (req, res) => {
+  const { current, previous } = await detectReleases();
+  if (!current || !previous) {
+    return res.status(400).json({ error: 'Need at least two releases' });
+  }
+
+  const currentMeta = path.join(releasesDir, current, 'META');
+  const previousMeta = path.join(releasesDir, previous, 'META');
+  const result = [];
+
+  try {
+    const currFiles = await fsp.readdir(currentMeta);
+    const prevFiles = await fsp.readdir(previousMeta);
+    const all = Array.from(new Set([...currFiles, ...prevFiles]));
+
+    for (const name of all) {
+      const curSize = await safeStatSize(path.join(currentMeta, name));
+      const prevSize = await safeStatSize(path.join(previousMeta, name));
+      if (curSize === null && prevSize === null) continue;
+      result.push({ name, current: curSize, previous: prevSize });
+    }
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+
+  res.json({ current, previous, files: result });
 });
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
+  console.log(`Using releases directory: ${releasesDir}`);
 });


### PR DESCRIPTION
## Summary
- expose `detectReleases` helper and new `/api/file-size-diff` API
- add compare file sizes button and table on the main page
- include basic table styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864067178a48327b2bfdbb37da39497