### PR TITLE
Add line count diff feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
   <div class="container">
     <h1>UMLS Release QA</h1>
     <div id="status"></div>
-    <button id="compare-sizes">Compare File Sizes</button>
-    <div id="size-results"></div>
+    <button id="compare-lines">Compare Line Counts</button>
+    <div id="line-results"></div>
   </div>
 
   <script type="module">
@@ -41,11 +41,11 @@
     }
     checkReleases();
 
-    document.getElementById('compare-sizes').addEventListener('click', async () => {
-      const results = document.getElementById('size-results');
+    document.getElementById('compare-lines').addEventListener('click', async () => {
+      const results = document.getElementById('line-results');
       results.innerHTML = '<p>Comparing...</p>';
       try {
-        const resp = await fetch('/api/file-size-diff');
+        const resp = await fetch('/api/line-count-diff');
         if (!resp.ok) {
           results.innerHTML = `<p style="color:red">Failed: ${resp.status}</p>`;
           return;
@@ -56,18 +56,24 @@
           results.innerHTML = '<p>No files found.</p>';
           return;
         }
-        let html = `<h3>File Size Comparison (${current} vs ${previous})</h3>`;
-        html += '<table><thead><tr><th>File</th><th>Previous (bytes)</th><th>Current (bytes)</th><th>Change</th><th>% Change</th></tr></thead><tbody>';
+        let html = `<h3>Line Count Comparison (${current} vs ${previous})</h3>`;
+        html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th></tr></thead><tbody>';
+        const unchanged = [];
         for (const f of files) {
           const prev = f.previous ?? 0;
           const cur = f.current ?? 0;
           const diff = cur - prev;
-          const percent = prev ? (diff / prev) * 100 : 0;
-          const highlight = percent > 5 ? ' style="background:#fffa90"' : '';
+          if (diff === 0) {
+            unchanged.push(f.name);
+            continue;
+          }
           const decrease = diff < 0 ? ' style="color:red"' : '';
-          html += `<tr${highlight}><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td><td${decrease}>${percent.toFixed(2)}%</td></tr>`;
+          html += `<tr><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td></tr>`;
         }
         html += '</tbody></table>';
+        if (unchanged.length) {
+          html += `<p>Unchanged files: ${unchanged.join(', ')}</p>`;
+        }
         results.innerHTML = html;
       } catch (err) {
         results.innerHTML = `<p style="color:red">Error: ${err.message}</p>`;


### PR DESCRIPTION
## Summary
- add recursive line counting API
- update frontend to show line differences

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864236bfec88327bbc7b62eb53e6b60