### PR TITLE
Add preprocessing UI and endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
     <h1>UMLS Release QA</h1>
     <div id="status"></div>
     <div id="sab-summary"></div>
+    <button id="run-preprocess">Run Preprocessing</button>
+    <div id="preprocess-results"></div>
     <button id="compare-lines">Compare Line Counts</button>
     <div id="line-results"></div>
   </div>
@@ -52,6 +54,23 @@
       } catch {}
     }
     loadSABSummary();
+
+    document.getElementById('run-preprocess').addEventListener('click', async () => {
+      const output = document.getElementById('preprocess-results');
+      output.innerHTML = '<p>Running preprocessing...</p>';
+      try {
+        const resp = await fetch('/api/preprocess', { method: 'POST' });
+        if (!resp.ok) {
+          output.innerHTML = `<p style="color:red">Failed: ${resp.status}</p>`;
+          return;
+        }
+        const data = await resp.json();
+        output.innerHTML = `<p>${data.message}</p>`;
+        loadSABSummary();
+      } catch (err) {
+        output.innerHTML = `<p style="color:red">Error: ${err.message}</p>`;
+      }
+    });
 
     document.getElementById('compare-lines').addEventListener('click', async () => {
       const results = document.getElementById('line-results');

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const readline = require('readline');
+const { exec } = require('child_process');
 const fsp = fs.promises;
 const reportsDir = path.join(__dirname, 'reports');
 
@@ -77,6 +78,17 @@ async function listFiles(dir, base = dir) {
   }
   return result;
 }
+
+app.post('/api/preprocess', (req, res) => {
+  const script = path.join(__dirname, 'preprocess.js');
+  exec(`node ${script}`, { cwd: __dirname }, (error, stdout, stderr) => {
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+    res.json({ message: 'Preprocessing complete.' });
+  });
+});
 
 app.get('/api/line-count-diff', async (req, res) => {
   const { current, previous } = await detectReleases();


### PR DESCRIPTION
## Summary
- add a new **Run Preprocessing** button before the Compare Line Counts button
- call new `/api/preprocess` endpoint from the page
- implement `/api/preprocess` in server to execute `preprocess.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864380177688327aff5f2747087384b