### PR TITLE
Switch SAB diff to JSON and stream preprocess progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,30 +46,39 @@
 
     async function loadSABSummary() {
       try {
-        const resp = await fetch('reports/SAB_TTY_count_differences.html');
-        if (resp.ok) {
-          const html = await resp.text();
-          document.getElementById('sab-summary').innerHTML = html;
+        const resp = await fetch('/api/sab-diff');
+        if (!resp.ok) return;
+        const data = await resp.json();
+        const { summary, current, previous } = data;
+        if (!summary.length) return;
+        let html = `<h3>SAB/TTY Differences (${current} vs ${previous})</h3>`;
+        html += '<table><thead><tr><th>SAB</th><th>TTY</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th></tr></thead><tbody>';
+        for (const row of summary) {
+          const style = row.Difference < 0 ? ' style="color:red"' : '';
+          const pct = isFinite(row.Percent) ? row.Percent.toFixed(2) : 'inf';
+          html += `<tr><td>${row.SAB}</td><td>${row.TTY}</td><td>${row.Previous}</td><td>${row.Current}</td><td${style}>${row.Difference}</td><td>${pct}</td></tr>`;
         }
+        html += '</tbody></table>';
+        document.getElementById('sab-summary').innerHTML = html;
       } catch {}
     }
     loadSABSummary();
 
-    document.getElementById('run-preprocess').addEventListener('click', async () => {
+    document.getElementById('run-preprocess').addEventListener('click', () => {
       const output = document.getElementById('preprocess-results');
       output.innerHTML = '<p>Running preprocessing...</p>';
-      try {
-        const resp = await fetch('/api/preprocess', { method: 'POST' });
-        if (!resp.ok) {
-          output.innerHTML = `<p style="color:red">Failed: ${resp.status}</p>`;
-          return;
-        }
-        const data = await resp.json();
-        output.innerHTML = `<p>${data.message}</p>`;
+      const es = new EventSource('/api/preprocess-stream');
+      es.onmessage = (e) => {
+        output.insertAdjacentHTML('beforeend', `<pre>${e.data}</pre>`);
+      };
+      es.addEventListener('done', () => {
+        es.close();
         loadSABSummary();
-      } catch (err) {
-        output.innerHTML = `<p style="color:red">Error: ${err.message}</p>`;
-      }
+      });
+      es.onerror = () => {
+        output.insertAdjacentHTML('beforeend', '<p style="color:red">Error running preprocessing.</p>');
+        es.close();
+      };
     });
 
     document.getElementById('compare-lines').addEventListener('click', async () => {

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const readline = require('readline');
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
 const fsp = fs.promises;
 const reportsDir = path.join(__dirname, 'reports');
 
@@ -103,6 +103,34 @@ app.post('/api/preprocess', (req, res) => {
   });
 });
 
+app.get('/api/preprocess-stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+
+  const script = path.join(__dirname, 'preprocess.js');
+  const child = spawn('node', [script], { cwd: __dirname });
+
+  child.stdout.on('data', chunk => {
+    const data = chunk.toString().trim();
+    if (data) {
+      res.write(`data: ${data}\n\n`);
+    }
+  });
+
+  child.stderr.on('data', chunk => {
+    const data = chunk.toString().trim();
+    if (data) {
+      res.write(`data: ERROR: ${data}\n\n`);
+    }
+  });
+
+  child.on('close', code => {
+    res.write(`event: done\ndata: ${code}\n\n`);
+    res.end();
+  });
+});
+
 app.get('/api/line-count-diff', async (req, res) => {
   const { current, previous } = await detectReleases();
   if (!current || !previous) {
@@ -139,6 +167,24 @@ app.get('/api/line-count-diff', async (req, res) => {
   }
 
   res.json({ current, previous, files: result });
+});
+
+app.get('/api/sab-diff', async (req, res) => {
+  const { current, previous } = await detectReleases();
+  if (!current || !previous) {
+    res.status(400).json({ error: 'Need at least two releases' });
+    return;
+  }
+
+  const precomputed = path.join(reportsDir, 'SAB_TTY_count_differences.json');
+  try {
+    const data = await fsp.readFile(precomputed, 'utf-8');
+    res.setHeader('Content-Type', 'application/json');
+    res.send(data);
+    return;
+  } catch {}
+
+  res.status(404).json({ error: 'Report not found. Run preprocessing.' });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- generate SAB/TTY difference data as JSON instead of HTML
- emit progress logs from `preprocess.js`
- add `/api/preprocess-stream` SSE endpoint
- add `/api/sab-diff` endpoint for JSON summary
- update UI to consume new endpoints and display preprocessing progress

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run preprocess` *(fails: Need at least two releases in releases/)*

------
https://chatgpt.com/codex/tasks/task_e_686446c0465c832787d99e0b0a665b57