### PR TITLE
Increase memory for preprocessing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
-    "preprocess": "node preprocess.js"
+    "preprocess": "node --max-old-space-size=8192 preprocess.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -128,7 +128,7 @@ app.get('/api/preprocess', (req, res) => {
 
 app.post('/api/preprocess', (req, res) => {
   const script = path.join(__dirname, 'preprocess.js');
-  exec(`node ${script}`, { cwd: __dirname }, (error, stdout, stderr) => {
+  exec(`node --max-old-space-size=8192 ${script}`, { cwd: __dirname }, (error, stdout, stderr) => {
     if (error) {
       // Detect the common "not enough releases" message and return a 400
       const msg = (stderr || error.message || '').trim();
@@ -149,7 +149,7 @@ app.get('/api/preprocess-stream', (req, res) => {
   res.setHeader('Connection', 'keep-alive');
 
   const script = path.join(__dirname, 'preprocess.js');
-  const child = spawn('node', [script], { cwd: __dirname });
+  const child = spawn('node', ['--max-old-space-size=8192', script], { cwd: __dirname });
 
   child.stdout.on('data', chunk => {
     const data = chunk.toString().trim();


### PR DESCRIPTION
## Summary
- bump memory limit to 8GB when running `preprocess.js`
- update server to pass `--max-old-space-size=8192` for preprocessing commands

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864564562308327b087a7809a642305