### PR TITLE
Add table reports and link integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,18 +187,20 @@
           return;
         }
         let html = `<h3>Line Count Comparison (${current} vs ${previous})</h3>`;
-        html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th></tr></thead><tbody>';
+        html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th><th>Report</th></tr></thead><tbody>';
         const unchanged = [];
         for (const f of files) {
           const prev = f.previous ?? 0;
           const cur = f.current ?? 0;
           const diff = cur - prev;
+          const pct = isFinite(f.percent) ? f.percent.toFixed(2) : 'inf';
           if (diff === 0) {
             unchanged.push(f.name);
             continue;
           }
           const decrease = diff < 0 ? ' style="color:red"' : '';
-          html += `<tr><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td></tr>`;
+          const linkCell = f.link ? `<a href="reports/${f.link}">view</a>` : '';
+          html += `<tr><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td><td>${pct}</td><td>${linkCell}</td></tr>`;
         }
         html += '</tbody></table>';
         if (unchanged.length) {

--- a/server.js
+++ b/server.js
@@ -199,7 +199,17 @@ app.get('/api/line-count-diff', async (req, res) => {
       const curCount = await safeLineCount(path.join(currentMeta, name));
       const prevCount = await safeLineCount(path.join(previousMeta, name));
       if (curCount === null && prevCount === null) continue;
-      result.push({ name, current: curCount, previous: prevCount });
+      const diff = (curCount ?? 0) - (prevCount ?? 0);
+      const percent = prevCount === 0 || prevCount === null ? Infinity : (diff / prevCount * 100);
+      let link = '';
+      const base = path.basename(name);
+      if (/^MRCONSO\.RRF$/i.test(base)) link = 'MRCONSO_report.html';
+      else if (/^MRSTY\.RRF$/i.test(base)) link = 'MRSTY_report.html';
+      else if (/^MRSAB\.RRF$/i.test(base)) link = 'MRSAB_report.html';
+      else if (/^MRDEF\.RRF$/i.test(base)) link = 'MRDEF_report.html';
+      else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
+      else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
+      result.push({ name, current: curCount, previous: prevCount, diff, percent, link });
     }
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -216,7 +226,7 @@ app.get('/api/sab-diff', async (req, res) => {
     return;
   }
 
-  const precomputed = path.join(reportsDir, 'SAB_TTY_count_differences.json');
+  const precomputed = path.join(reportsDir, 'MRCONSO_report.json');
   try {
     const data = await fsp.readFile(precomputed, 'utf-8');
     res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
## Summary
- add percent change and report links to line count report
- rename SAB/TTY report to `MRCONSO_report.json`
- generate HTML summary for MRCONSO and new tables MRSTY/MRSAB/MRDEF/MRREL/MRSAT
- expose extra fields from API and update UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68652fd392b08327bfe92d04473a3a30