### PR TITLE
Enable editing and add note placeholders

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -31,3 +31,7 @@ th, td {
   padding: 4px 8px;
   text-align: left;
 }
+
+.note {
+  min-height: 1em;
+}

--- a/index.html
+++ b/index.html
@@ -9,15 +9,18 @@
   <div class="container">
     <h1 id="page-title" class="editable">UMLS Release QA</h1>
     <div class="admin-controls">
-      <button id="admin-toggle" class="editable">Admin Mode</button>
-      <button id="save-texts" class="editable" style="display:none">Save</button>
+      <button id="save-texts" class="editable">Save</button>
     </div>
     <div id="status"></div>
+    <p class="editable note"></p>
     <div id="sab-summary"></div>
+    <p class="editable note"></p>
     <button id="run-preprocess" class="editable">Run Preprocessing</button>
     <div id="preprocess-results"></div>
+    <p class="editable note"></p>
     <button id="compare-lines" class="editable">Compare Line Counts</button>
     <div id="line-results"></div>
+    <p class="editable note"></p>
   </div>
 
   <script type="module">
@@ -35,50 +38,26 @@
       document.getElementById('page-title').textContent = texts.header || 'UMLS Release QA';
       document.getElementById('run-preprocess').textContent = texts.runPreprocessButton || 'Run Preprocessing';
       document.getElementById('compare-lines').textContent = texts.compareLinesButton || 'Compare Line Counts';
-      adminToggle.textContent = texts.adminToggleOff || 'Admin Mode';
       saveBtn.textContent = texts.saveButton || 'Save';
     }
 
-    loadTexts();
-
-    const adminToggle = document.getElementById('admin-toggle');
     const saveBtn = document.getElementById('save-texts');
     function setEditable(on) {
       document.querySelectorAll('.editable').forEach(el => {
         el.contentEditable = on;
       });
     }
-    adminToggle.addEventListener('click', () => {
-      const editing = adminToggle.dataset.editing === 'true';
-      if (editing) {
-        texts.adminToggleOn = adminToggle.textContent;
-        adminToggle.dataset.editing = 'false';
-        adminToggle.textContent = texts.adminToggleOff || 'Admin Mode';
-        saveBtn.style.display = 'none';
-        setEditable(false);
-      } else {
-        texts.adminToggleOff = adminToggle.textContent;
-        adminToggle.dataset.editing = 'true';
-        adminToggle.textContent = texts.adminToggleOn || 'Exit Admin';
-        saveBtn.style.display = '';
-        setEditable(true);
-      }
+    loadTexts().then(() => {
+      setEditable(true);
     });
 
     saveBtn.addEventListener('click', async () => {
-      if (adminToggle.dataset.editing === 'true') {
-        texts.adminToggleOn = adminToggle.textContent;
-      } else {
-        texts.adminToggleOff = adminToggle.textContent;
-      }
       texts.saveButton = saveBtn.textContent;
       const payload = {
         title: document.title,
         header: document.getElementById('page-title').textContent,
         runPreprocessButton: document.getElementById('run-preprocess').textContent,
         compareLinesButton: document.getElementById('compare-lines').textContent,
-        adminToggleOn: texts.adminToggleOn,
-        adminToggleOff: texts.adminToggleOff,
         saveButton: texts.saveButton
       };
       try {

--- a/server.js
+++ b/server.js
@@ -11,8 +11,6 @@ const defaultTexts = {
   header: 'UMLS Release QA',
   runPreprocessButton: 'Run Preprocessing',
   compareLinesButton: 'Compare Line Counts',
-  adminToggleOff: 'Admin Mode',
-  adminToggleOn: 'Exit Admin',
   saveButton: 'Save'
 };
 

--- a/texts.json
+++ b/texts.json
@@ -3,7 +3,5 @@
   "header": "UMLS Release QA in progress",
   "runPreprocessButton": "Run Preprocessing",
   "compareLinesButton": "Compare Line Counts",
-  "adminToggleOff": "Admin Mode",
-  "adminToggleOn": "Exit Admin",
   "saveButton": "Save"
 }


### PR DESCRIPTION
## Summary
- remove admin toggle button and always enable editing
- add editable note blocks between page sections
- update styles for note blocks
- clean up unused text entries

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686530d5ac088327bcf76960f804b75c