### PR TITLE
Avoid rerunning preprocessing when reports are current

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -6,6 +6,7 @@ const readline = require('readline');
 const releasesDir = path.join(__dirname, 'releases');
 const reportsDir = path.join(__dirname, 'reports');
 const diffsDir = path.join(reportsDir, 'diffs');
+const configFile = path.join(reportsDir, 'config.json');
 
 async function detectReleases() {
   let releaseList = [];
@@ -322,6 +323,8 @@ async function generateCountReport(current, previous, fileName, indices, tableNa
   await generateCountReport(current, previous, 'MRDEF.RRF', [4], 'MRDEF');
   await generateCountReport(current, previous, 'MRREL.RRF', [3], 'MRREL');
   await generateCountReport(current, previous, 'MRSAT.RRF', [9], 'MRSAT');
+  await fsp.mkdir(reportsDir, { recursive: true });
+  await fsp.writeFile(configFile, JSON.stringify({ current, previous }, null, 2));
   console.log('Reports generated in', reportsDir);
 })();
 

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const readline = require('readline');
 const { exec, spawn } = require('child_process');
 const fsp = fs.promises;
 const reportsDir = path.join(__dirname, 'reports');
+const configFile = path.join(reportsDir, 'config.json');
 const textsFile = path.join(__dirname, 'texts.json');
 const defaultTexts = {
   title: 'UMLS Release QA',
@@ -126,7 +127,19 @@ app.get('/api/preprocess', (req, res) => {
   res.status(405).json({ error: 'Use POST to run preprocessing.' });
 });
 
-app.post('/api/preprocess', (req, res) => {
+app.post('/api/preprocess', async (req, res) => {
+  const { current, previous } = await detectReleases();
+  if (!current || !previous) {
+    res.status(400).json({ error: 'Need at least two releases' });
+    return;
+  }
+  try {
+    const cfg = JSON.parse(await fsp.readFile(configFile, 'utf-8'));
+    if (cfg.current === current && cfg.previous === previous) {
+      res.json({ message: 'Preprocessing already up to date.' });
+      return;
+    }
+  } catch {}
   const script = path.join(__dirname, 'preprocess.js');
   exec(`node --max-old-space-size=8192 ${script}`, { cwd: __dirname }, (error, stdout, stderr) => {
     if (error) {
@@ -143,10 +156,23 @@ app.post('/api/preprocess', (req, res) => {
   });
 });
 
-app.get('/api/preprocess-stream', (req, res) => {
+app.get('/api/preprocess-stream', async (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
+
+  const { current, previous } = await detectReleases();
+  if (current && previous) {
+    try {
+      const cfg = JSON.parse(await fsp.readFile(configFile, 'utf-8'));
+      if (cfg.current === current && cfg.previous === previous) {
+        res.write(`data: Preprocessing already up to date.\n\n`);
+        res.write(`event: done\ndata: 0\n\n`);
+        res.end();
+        return;
+      }
+    } catch {}
+  }
 
   const script = path.join(__dirname, 'preprocess.js');
   const child = spawn('node', ['--max-old-space-size=8192', script], { cwd: __dirname });


### PR DESCRIPTION
## Summary
- add `config.json` to store the releases used for reports
- skip preprocessing in both API endpoints when the config matches
- write current release info to `config.json` after generating reports

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686534ddf4508327a3cbddaf0af8c033