### PR TITLE
Adjust preprocess output and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
       };
       es.addEventListener('done', () => {
         es.close();
-        loadSABSummary();
+        output.insertAdjacentHTML('beforeend', '<p>MRCONSO report done.</p>');
       });
       es.onerror = () => {
         output.insertAdjacentHTML('beforeend', '<p style="color:red">Error running preprocessing.</p>');

--- a/preprocess.js
+++ b/preprocess.js
@@ -315,8 +315,9 @@ async function generateCountReport(current, previous, fileName, indices, tableNa
   }
   console.log(`Processing line counts for ${current} vs ${previous}...`);
   await generateLineCountDiff(current, previous);
-  console.log('Generating SAB/TTY differences...');
+  console.log('Generating MRCONSO report...');
   await generateSABDiff(current, previous);
+  console.log('MRCONSO report done.');
   console.log('Generating additional table reports...');
   await generateCountReport(current, previous, 'MRSTY.RRF', [3], 'MRSTY');
   await generateCountReport(current, previous, 'MRSAB.RRF', [3], 'MRSAB');


### PR DESCRIPTION
## Summary
- tweak preprocessing message so it announces when the MRCONSO report is complete
- avoid automatically displaying the SAB/TTY table after preprocessing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865656f88708327a63e96f0c9baa0c4