### PR TITLE
Auto display line counts and add report status

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
       es.addEventListener('done', () => {
         es.close();
         output.insertAdjacentHTML('beforeend', '<p>MRCONSO report done.</p>');
+        loadLineCounts();
       });
       es.onerror = () => {
         output.insertAdjacentHTML('beforeend', '<p style="color:red">Error running preprocessing.</p>');
@@ -140,7 +141,7 @@
       };
     });
 
-    document.getElementById('compare-lines').addEventListener('click', async () => {
+    async function loadLineCounts() {
       const results = document.getElementById('line-results');
       results.innerHTML = '<p>Comparing...</p>';
       try {
@@ -156,7 +157,7 @@
           return;
         }
         let html = `<h3>Line Count Comparison (${current} vs ${previous})</h3>`;
-        html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th><th>Report</th></tr></thead><tbody>';
+        html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th><th>Status</th><th>Report</th></tr></thead><tbody>';
         const unchanged = [];
         for (const f of files) {
           const prev = f.previous ?? 0;
@@ -171,7 +172,7 @@
           }
           const decrease = diff < 0 ? ' style="color:red"' : '';
           const linkCell = f.link ? `<a href="reports/${f.link}">view</a>` : '';
-          html += `<tr><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td><td>${pct}</td><td>${linkCell}</td></tr>`;
+          html += `<tr><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td><td>${pct}</td><td>${f.status}</td><td>${linkCell}</td></tr>`;
         }
         html += '</tbody></table>';
         if (unchanged.length) {
@@ -181,7 +182,9 @@
       } catch (err) {
         results.innerHTML = `<p style="color:red">Error: ${err.message}</p>`;
       }
-    });
+    }
+
+    document.getElementById('compare-lines').addEventListener('click', loadLineCounts);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- automatically fetch line count comparison once preprocessing completes
- include report status in server API and generated HTML
- show new **Status** column in the web page
- ensure `reports/config.json` is written when line count results are generated or loaded

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865712a0af483279ed94882deaeb5cb