### PR TITLE
Auto display line counts and add report status

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
       es.addEventListener('done', () => {
         es.close();
         output.insertAdjacentHTML('beforeend', '<p>MRCONSO report done.</p>');
+        loadLineCounts();
       });
       es.onerror = () => {
         output.insertAdjacentHTML('beforeend', '<p style="color:red">Error running preprocessing.</p>');
@@ -140,7 +141,7 @@
       };
     });
 
-    document.getElementById('compare-lines').addEventListener('click', async () => {
+    async function loadLineCounts() {
       const results = document.getElementById('line-results');
       results.innerHTML = '<p>Comparing...</p>';
       try {
@@ -156,8 +157,9 @@
           return;
         }
         let html = `<h3>Line Count Comparison (${current} vs ${previous})</h3>`;
-        html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th><th>Report</th></tr></thead><tbody>';
+        html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th><th>Status</th><th>Report</th></tr></thead><tbody>';
         const unchanged = [];
+        let pending = false;
         for (const f of files) {
           const prev = f.previous ?? 0;
           const cur = f.current ?? 0;
@@ -171,17 +173,21 @@
           }
           const decrease = diff < 0 ? ' style="color:red"' : '';
           const linkCell = f.link ? `<a href="reports/${f.link}">view</a>` : '';
-          html += `<tr><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td><td>${pct}</td><td>${linkCell}</td></tr>`;
+          if (f.status !== 'ready') pending = true;
+          html += `<tr><td>${f.name}</td><td>${prev}</td><td>${cur}</td><td${decrease}>${diff}</td><td>${pct}</td><td>${f.status}</td><td>${linkCell}</td></tr>`;
         }
         html += '</tbody></table>';
         if (unchanged.length) {
           html += `<p>Unchanged files: ${unchanged.join(', ')}</p>`;
         }
         results.innerHTML = html;
+        if (pending) setTimeout(loadLineCounts, 5000);
       } catch (err) {
         results.innerHTML = `<p style="color:red">Error: ${err.message}</p>`;
       }
-    });
+    }
+
+    document.getElementById('compare-lines').addEventListener('click', loadLineCounts);
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -136,7 +136,9 @@ app.post('/api/preprocess', async (req, res) => {
       res.json({ message: 'Preprocessing already up to date.' });
       return;
     }
-  } catch {}
+  } catch (err) {
+    console.error('Failed to load precomputed diff:', err.message);
+  }
   const script = path.join(__dirname, 'preprocess.js');
   exec(`node --max-old-space-size=8192 ${script}`, { cwd: __dirname }, (error, stdout, stderr) => {
     if (error) {
@@ -168,7 +170,17 @@ app.get('/api/preprocess-stream', async (req, res) => {
         res.end();
         return;
       }
-    } catch {}
+    } catch {
+      try {
+        const alt = JSON.parse(await fsp.readFile(path.join(reportsDir, 'line-count-diff.json'), 'utf-8'));
+        if (alt.current === current && alt.previous === previous) {
+          res.write(`data: Preprocessing already up to date.\n\n`);
+          res.write(`event: done\ndata: 0\n\n`);
+          res.end();
+          return;
+        }
+      } catch {}
+    }
   }
 
   const script = path.join(__dirname, 'preprocess.js');
@@ -203,9 +215,22 @@ app.get('/api/line-count-diff', async (req, res) => {
 
   const precomputed = path.join(reportsDir, 'line-count-diff.json');
   try {
-    const data = await fsp.readFile(precomputed, 'utf-8');
-    res.setHeader('Content-Type', 'application/json');
-    res.send(data);
+    const data = JSON.parse(await fsp.readFile(precomputed, 'utf-8'));
+    for (const file of data.files || []) {
+      if (file.link) {
+        try {
+          await fsp.access(path.join(reportsDir, file.link));
+          file.status = 'ready';
+        } catch {
+          file.status = 'missing';
+        }
+      } else {
+        file.status = 'n/a';
+      }
+    }
+    await fsp.mkdir(reportsDir, { recursive: true });
+    await fsp.writeFile(configFile, JSON.stringify({ current: data.current, previous: data.previous }, null, 2));
+    res.json(data);
     return;
   } catch {}
 
@@ -232,28 +257,39 @@ app.get('/api/line-count-diff', async (req, res) => {
       else if (/^MRDEF\.RRF$/i.test(base)) link = 'MRDEF_report.html';
       else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
       else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
-      result.push({ name, current: curCount, previous: prevCount, diff, percent, link });
+      let status = 'n/a';
+      if (link) {
+        try {
+          await fsp.access(path.join(reportsDir, link));
+          status = 'ready';
+        } catch {
+          status = 'missing';
+        }
+      }
+      result.push({ name, current: curCount, previous: prevCount, diff, percent, link, status });
     }
 
     await fsp.mkdir(reportsDir, { recursive: true });
     await fsp.writeFile(precomputed, JSON.stringify({ current, previous, files: result }, null, 2));
 
     let html = `<h3>Line Count Comparison (${current} vs ${previous})</h3>`;
-    html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th><th>Report</th></tr></thead><tbody>';
+    html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Change</th><th>%</th><th>Status</th><th>Report</th></tr></thead><tbody>';
     const unchanged = [];
     for (const f of result) {
       if (f.diff === 0) { unchanged.push(f.name); continue; }
       const style = f.diff < 0 ? ' style="color:red"' : '';
       const pct = isFinite(f.percent) ? f.percent.toFixed(2) : 'inf';
       const linkCell = f.link ? `<a href="${f.link}">view</a>` : '';
-      html += `<tr><td>${f.name}</td><td>${f.previous ?? 0}</td><td>${f.current ?? 0}</td><td${style}>${f.diff}</td><td>${pct}</td><td>${linkCell}</td></tr>`;
+      html += `<tr><td>${f.name}</td><td>${f.previous ?? 0}</td><td>${f.current ?? 0}</td><td${style}>${f.diff}</td><td>${pct}</td><td>${f.status}</td><td>${linkCell}</td></tr>`;
     }
     html += '</tbody></table>';
     if (unchanged.length) {
       html += `<p>Unchanged files: ${unchanged.join(', ')}</p>`;
     }
     await fsp.writeFile(path.join(reportsDir, 'line-count-diff.html'), html);
+    await fsp.writeFile(configFile, JSON.stringify({ current, previous }, null, 2));
   } catch (err) {
+    console.error('Error generating line count diff:', err.message);
     res.status(500).json({ error: err.message });
     return;
   }


### PR DESCRIPTION
## Summary
- automatically fetch line count comparison once preprocessing completes
- include report status in server API and generated HTML
- show new **Status** column in the web page
- ensure `reports/config.json` is written when line count results are generated or loaded
- skip generating line counts if `line-count-diff.json` already exists and add better error logging
- refresh line count table until all reports are ready

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865712a0af483279ed94882deaeb5cb