### PR TITLE
Add HTML wrapper for report tables

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -8,6 +8,10 @@ const reportsDir = path.join(__dirname, 'reports');
 const diffsDir = path.join(reportsDir, 'diffs');
 const configFile = path.join(reportsDir, 'config.json');
 
+function wrapHtml(title, body) {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css"></head><body>${body}</body></html>`;
+}
+
 async function detectReleases() {
   let releaseList = [];
   try {
@@ -101,7 +105,8 @@ async function generateLineCountDiff(current, previous) {
   if (unchanged.length) {
     html += `<p>Unchanged files: ${unchanged.join(', ')}</p>`;
   }
-  await fsp.writeFile(path.join(reportsDir, 'line-count-diff.html'), html);
+  const wrapped = wrapHtml('Line Count Comparison', html);
+  await fsp.writeFile(path.join(reportsDir, 'line-count-diff.html'), wrapped);
 }
 
 function escapeHTML(str) {
@@ -275,7 +280,8 @@ async function generateSABDiff(current, previous) {
     html += `<tr><td>${row.SAB}</td><td>${row.TTY}</td><td>${row.Previous}</td><td>${row.Current}</td><td${style}>${row.Difference}</td><td>${pct}</td><td>${linkCell}</td></tr>`;
   }
   html += '</tbody></table>';
-  await fsp.writeFile(path.join(reportsDir, 'MRCONSO_report.html'), html);
+  const wrapped = wrapHtml('MRCONSO Report', html);
+  await fsp.writeFile(path.join(reportsDir, 'MRCONSO_report.html'), wrapped);
 }
 
 async function generateCountReport(current, previous, fileName, indices, tableName) {
@@ -303,7 +309,8 @@ async function generateCountReport(current, previous, fileName, indices, tableNa
     html += `<tr><td>${escapeHTML(row.Key)}</td><td>${row.Previous}</td><td>${row.Current}</td><td${style}>${row.Difference}</td><td>${pctTxt}</td></tr>`;
   }
   html += '</tbody></table>';
-  await fsp.writeFile(path.join(reportsDir, `${tableName}_report.html`), html);
+  const wrapped = wrapHtml(`${tableName} Report`, html);
+  await fsp.writeFile(path.join(reportsDir, `${tableName}_report.html`), wrapped);
 }
 
 (async () => {

--- a/server.js
+++ b/server.js
@@ -14,6 +14,10 @@ const defaultTexts = {
   compareLinesButton: 'Compare Line Counts'
 };
 
+function wrapHtml(title, body) {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css"></head><body>${body}</body></html>`;
+}
+
 const app = express();
 const PORT = process.env.PORT || 8080;
 const releasesDir = process.env.RELEASES_DIR || path.join(__dirname, 'releases');
@@ -286,7 +290,8 @@ app.get('/api/line-count-diff', async (req, res) => {
     if (unchanged.length) {
       html += `<p>Unchanged files: ${unchanged.join(', ')}</p>`;
     }
-    await fsp.writeFile(path.join(reportsDir, 'line-count-diff.html'), html);
+    const wrapped = wrapHtml('Line Count Comparison', html);
+    await fsp.writeFile(path.join(reportsDir, 'line-count-diff.html'), wrapped);
     await fsp.writeFile(configFile, JSON.stringify({ current, previous }, null, 2));
   } catch (err) {
     console.error('Error generating line count diff:', err.message);


### PR DESCRIPTION
## Summary
- add a `wrapHtml` helper for generated reports
- apply wrapper when creating report HTML so `styles.css` is loaded

## Testing
- `npm test` *(fails: no test specified)*
- `node preprocess.js` *(fails: Need at least two releases in releases/)*

------
https://chatgpt.com/codex/tasks/task_e_686590f184c883278d2e9360212a43ab