### PR TITLE
UI tweaks and message updates

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -48,3 +48,11 @@ tbody tr:hover {
   border: 1px dashed #888;
   padding: 4px;
 }
+
+#status p,
+#sab-summary p,
+#preprocess-results p,
+#preprocess-results pre,
+#line-results p {
+  margin: 2px 0;
+}

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   <div class="container">
     <h1 id="page-title" class="editable">UMLS Release QA</h1>
     <div id="status"></div>
-    <p class="editable note"></p>
     <div id="sab-summary"></div>
     <p class="editable note"></p>
     <button id="run-preprocess" class="editable">Run Reports</button>
@@ -78,7 +77,7 @@
           status.innerHTML = `
             <p>Current release: <strong>${current}</strong></p>
             <p>Previous release: <strong>${previous}</strong></p>
-            <p style="color:green">Folders are ready for comparison.</p>
+            <p style="color:green">Releases are ready for comparison.</p>
           `;
         } else {
           status.innerHTML = `

--- a/server.js
+++ b/server.js
@@ -133,7 +133,7 @@ app.post('/api/preprocess', async (req, res) => {
   try {
     const cfg = JSON.parse(await fsp.readFile(configFile, 'utf-8'));
     if (cfg.current === current && cfg.previous === previous) {
-      res.json({ message: 'Preprocessing already up to date.' });
+      res.json({ message: 'Preprocessing complete.' });
       return;
     }
   } catch (err) {
@@ -165,7 +165,6 @@ app.get('/api/preprocess-stream', async (req, res) => {
     try {
       const cfg = JSON.parse(await fsp.readFile(configFile, 'utf-8'));
       if (cfg.current === current && cfg.previous === previous) {
-        res.write(`data: Preprocessing already up to date.\n\n`);
         res.write(`event: done\ndata: 0\n\n`);
         res.end();
         return;
@@ -174,7 +173,6 @@ app.get('/api/preprocess-stream', async (req, res) => {
       try {
         const alt = JSON.parse(await fsp.readFile(path.join(reportsDir, 'line-count-diff.json'), 'utf-8'));
         if (alt.current === current && alt.previous === previous) {
-          res.write(`data: Preprocessing already up to date.\n\n`);
           res.write(`event: done\ndata: 0\n\n`);
           res.end();
           return;


### PR DESCRIPTION
## Summary
- remove empty editable note near release status
- change 'Folders' message to 'Releases'
- tighten spacing around non-report elements
- simplify preprocessing status text

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68659257832483279207cc1fb3a67b25