### PR TITLE
Fix flashing table in line count view

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
           html += `<p>Unchanged files: ${unchanged.join(', ')}</p>`;
         }
         results.innerHTML = html;
-        if (pending) setTimeout(loadLineCounts, 5000);
+        if (pending && lineInterval) setTimeout(loadLineCounts, 5000);
       } catch (err) {
         results.innerHTML = `<p style="color:red">Error: ${err.message}</p>`;
       }


### PR DESCRIPTION
## Summary
- stop auto-refresh of line count table once preprocessing is finished

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686592e8d2348327a62d370cf0f267fd