### PR TITLE
Remove unused line count button

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     <button id="run-preprocess" class="editable">Run Reports</button>
     <div id="preprocess-results"></div>
     <p class="editable note"></p>
-    <button id="compare-lines" class="editable">Compare Line Counts</button>
     <div id="line-results"></div>
     <p class="editable note"></p>
   </div>
@@ -34,7 +33,6 @@
       document.title = texts.title || 'UMLS Release QA';
       document.getElementById('page-title').textContent = texts.header || 'UMLS Release QA';
       document.getElementById('run-preprocess').textContent = texts.runPreprocessButton || 'Run Reports';
-      document.getElementById('compare-lines').textContent = texts.compareLinesButton || 'Compare Line Counts';
     }
     function setEditable(on) {
       document.querySelectorAll('.editable').forEach(el => {
@@ -52,8 +50,7 @@
       const payload = {
         title: document.title,
         header: document.getElementById('page-title').textContent,
-        runPreprocessButton: document.getElementById('run-preprocess').textContent,
-        compareLinesButton: document.getElementById('compare-lines').textContent
+        runPreprocessButton: document.getElementById('run-preprocess').textContent
       };
       try {
         await fetch('/api/texts', {
@@ -195,7 +192,6 @@
       }
     }
 
-    document.getElementById('compare-lines').addEventListener('click', loadLineCounts);
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -10,8 +10,7 @@ const textsFile = path.join(__dirname, 'texts.json');
 const defaultTexts = {
   title: 'UMLS Release QA',
   header: 'UMLS Release QA',
-  runPreprocessButton: 'Run Reports',
-  compareLinesButton: 'Compare Line Counts'
+  runPreprocessButton: 'Run Reports'
 };
 
 function wrapHtml(title, body) {

--- a/texts.json
+++ b/texts.json
@@ -2,6 +2,5 @@
   "title": "UMLS Release QA",
   "header": "UMLS Release QA in progress",
   "runPreprocessButton": "Run Reports",
-  "compareLinesButton": "Compare Line Counts",
   "saveButton": "Save"
 }


### PR DESCRIPTION
## Summary
- remove the Compare Line Counts button from the main page
- drop related text customization options

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68659397572883278a5c9d29b0f52d22