### PR TITLE
Fix saving editable notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
     <h1 id="page-title" class="editable">UMLS Release QA</h1>
     <div id="status"></div>
     <div id="sab-summary"></div>
-    <p class="editable note"></p>
+    <p id="note1" class="editable note"></p>
     <button id="run-preprocess" class="editable">Run Reports</button>
     <div id="preprocess-results"></div>
-    <p class="editable note"></p>
+    <p id="note2" class="editable note"></p>
     <button id="compare-lines" class="editable">Compare Line Counts</button>
     <div id="line-results"></div>
-    <p class="editable note"></p>
+    <p id="note3" class="editable note"></p>
   </div>
 
   <script type="module">
@@ -35,6 +35,9 @@
       document.getElementById('page-title').textContent = texts.header || 'UMLS Release QA';
       document.getElementById('run-preprocess').textContent = texts.runPreprocessButton || 'Run Reports';
       document.getElementById('compare-lines').textContent = texts.compareLinesButton || 'Compare Line Counts';
+      document.getElementById('note1').textContent = texts.note1 || '';
+      document.getElementById('note2').textContent = texts.note2 || '';
+      document.getElementById('note3').textContent = texts.note3 || '';
     }
     function setEditable(on) {
       document.querySelectorAll('.editable').forEach(el => {
@@ -53,7 +56,10 @@
         title: document.title,
         header: document.getElementById('page-title').textContent,
         runPreprocessButton: document.getElementById('run-preprocess').textContent,
-        compareLinesButton: document.getElementById('compare-lines').textContent
+        compareLinesButton: document.getElementById('compare-lines').textContent,
+        note1: document.getElementById('note1').textContent,
+        note2: document.getElementById('note2').textContent,
+        note3: document.getElementById('note3').textContent
       };
       try {
         await fetch('/api/texts', {

--- a/server.js
+++ b/server.js
@@ -11,7 +11,10 @@ const defaultTexts = {
   title: 'UMLS Release QA',
   header: 'UMLS Release QA',
   runPreprocessButton: 'Run Reports',
-  compareLinesButton: 'Compare Line Counts'
+  compareLinesButton: 'Compare Line Counts',
+  note1: '',
+  note2: '',
+  note3: ''
 };
 
 function wrapHtml(title, body) {

--- a/texts.json
+++ b/texts.json
@@ -2,5 +2,8 @@
   "title": "UMLS Release QA",
   "header": "UMLS Release QA in progress",
   "runPreprocessButton": "Run Reports",
-  "compareLinesButton": "Compare Line Counts"
+  "compareLinesButton": "Compare Line Counts",
+  "note1": "",
+  "note2": "",
+  "note3": ""
 }


### PR DESCRIPTION
## Summary
- assign IDs to note paragraphs and store their text
- persist notes from the client-side
- include notes in default texts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686594ae6cf48327990216906cd76c97