### PR TITLE
Improve report styling and access

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -32,7 +32,8 @@ table {
 thead {
   background-color: #f2f2f2;
 }
-th, td {
+table th,
+table td {
   border: 1px solid #ccc;
   padding: 6px 10px;
   text-align: left;

--- a/preprocess.js
+++ b/preprocess.js
@@ -9,11 +9,11 @@ const diffsDir = path.join(reportsDir, 'diffs');
 const configFile = path.join(reportsDir, 'config.json');
 
 function wrapHtml(title, body) {
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css"></head><body>${body}</body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css"></head><body><h1>${title}</h1>${body}</body></html>`;
 }
 
 function wrapDiffHtml(title, body) {
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css"></head><body>${body}</body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css"></head><body><h1>${title}</h1>${body}</body></html>`;
 }
 
 async function detectReleases() {

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ const defaultTexts = {
 };
 
 function wrapHtml(title, body) {
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css"></head><body>${body}</body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css"></head><body><h1>${title}</h1>${body}</body></html>`;
 }
 
 const app = express();
@@ -27,6 +27,7 @@ const releasesDir = process.env.RELEASES_DIR || path.join(__dirname, 'releases')
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname)));
+app.use('/reports', express.static(reportsDir));
 
 async function detectReleases() {
   let releaseList = [];


### PR DESCRIPTION
## Summary
- improve table cell border CSS
- add top-level headings to generated report pages
- explicitly serve `/reports` from Express

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c0a3e1eec8327b477ecfa2d3414ba