### PR TITLE
Add report config detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# UMLS Release QA
+
+This project generates HTML reports comparing two UMLS releases.
+
+## Configuration
+
+Report behavior can be configured by editing `report-config.json` in the project
+root. Currently the only option is:
+
+- `includeStyBreakdowns` – when `true` (default) the MRSTY report will include
+  per-SAB breakdowns for semantic types. Set to `false` to skip these detailed
+  tables.
+
+When preprocessing runs it stores the last used configuration in
+`reports/config.json`. If the current configuration and release selection match
+what was used previously, preprocessing is skipped.
+
+## Usage
+
+1. Place at least two release directories under `releases/`.
+2. Run `npm run preprocess` to generate reports.
+
+HTML reports will be saved to the `reports/` folder.

--- a/report-config.json
+++ b/report-config.json
@@ -1,0 +1,3 @@
+{
+  "includeStyBreakdowns": true
+}


### PR DESCRIPTION
## Summary
- add `report-config.json` for customizing reports
- skip preprocessing when configuration is unchanged
- allow disabling STY breakdowns via config
- document configuration options

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d201577b48327b0c918e1304bc5ec