### PR TITLE
Add MRRANK report

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
         ['MRREL_report.html', 'MRREL'],
         ['MRSTY_report.html', 'MRSTY'],
         ['MRDEF_report.html', 'MRDEF'],
+        ['MRRANK_report.html', 'MRRANK'],
         ['MRSAT_report.html', 'MRSAT']
       ];
       const rows = [];

--- a/preprocess.js
+++ b/preprocess.js
@@ -102,6 +102,7 @@ async function generateLineCountDiff(current, previous) {
     else if (/^MRSAB\.RRF$/i.test(base)) link = 'MRSAB_report.html';
     else if (/^MRDEF\.RRF$/i.test(base)) link = 'MRDEF_report.html';
     else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
+    else if (/^MRRANK\.RRF$/i.test(base)) link = 'MRRANK_report.html';
     else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
     result.push({ name, current: cur, previous: prev, diff, percent, link });
   }
@@ -789,6 +790,7 @@ async function generateMRRELReport(current, previous) {
   await generateMRSABChangeReport(current, previous);
   await generateCountReport(current, previous, 'MRDEF.RRF', [4], 'MRDEF');
   await generateMRRELReport(current, previous);
+  await generateCountReport(current, previous, 'MRRANK.RRF', [2, 3], 'MRRANK');
   await generateCountReport(current, previous, 'MRSAT.RRF', [9], 'MRSAT');
   await fsp.mkdir(reportsDir, { recursive: true });
   await fsp.writeFile(

--- a/server.js
+++ b/server.js
@@ -263,6 +263,7 @@ app.get('/api/line-count-diff', async (req, res) => {
       else if (/^MRSAB\.RRF$/i.test(base)) link = 'MRSAB_report.html';
       else if (/^MRDEF\.RRF$/i.test(base)) link = 'MRDEF_report.html';
       else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
+      else if (/^MRRANK\.RRF$/i.test(base)) link = 'MRRANK_report.html';
       else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
       let status = 'n/a';
       if (link) {


### PR DESCRIPTION
## Summary
- support generating `MRRANK` report in preprocess script
- expose the `MRRANK` report through the server and UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d3ecf4d9083278900a42fef140576