### PR TITLE
Add MRHIER SAB report

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,8 @@
         ['MRREL_report.html', 'MRREL'],
         ['MRSTY_report.html', 'MRSTY'],
         ['MRDEF_report.html', 'MRDEF'],
-        ['MRSAT_report.html', 'MRSAT']
+        ['MRSAT_report.html', 'MRSAT'],
+        ['MRHIER_report.html', 'MRHIER']
       ];
       const rows = [];
       let allReady = true;

--- a/preprocess.js
+++ b/preprocess.js
@@ -108,6 +108,7 @@ async function generateLineCountDiff(current, previous) {
     else if (/^MRDEF\.RRF$/i.test(base)) link = 'MRDEF_report.html';
     else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
     else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
+    else if (/^MRHIER\.RRF$/i.test(base)) link = 'MRHIER_report.html';
     result.push({ name, current: cur, previous: prev, diff, percent, link });
   }
 
@@ -823,8 +824,9 @@ async function generateMRRELReport(current, previous) {
     await generateCountReport(current, previous, 'MRSAB.RRF', [3], 'MRSAB');
     await generateCountReport(current, previous, 'MRDEF.RRF', [4], 'MRDEF');
     await generateCountReport(current, previous, 'MRSAT.RRF', [9], 'MRSAT');
+    await generateCountReport(current, previous, 'MRHIER.RRF', [4], 'MRHIER');
   } else {
-    console.log('Count report logic unchanged; skipping MRSAB/MRDEF/MRSAT counts.');
+    console.log('Count report logic unchanged; skipping MRSAB/MRDEF/MRSAT/MRHIER counts.');
   }
 
   if (runMRSABChange) {

--- a/server.js
+++ b/server.js
@@ -264,6 +264,7 @@ app.get('/api/line-count-diff', async (req, res) => {
       else if (/^MRDEF\.RRF$/i.test(base)) link = 'MRDEF_report.html';
       else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
       else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
+      else if (/^MRHIER\.RRF$/i.test(base)) link = 'MRHIER_report.html';
       let status = 'n/a';
       if (link) {
         try {


### PR DESCRIPTION
## Summary
- add MRHIER_report to generated reports list
- link MRHIER report from line count diff helper logic
- generate MRHIER count per SAB in preprocessing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d4014da708327b37221c1b39bd951