### PR TITLE
Add MRDOC report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ what was used previously, preprocessing is skipped.
 2. Run `npm run preprocess` to generate reports with HTML output.
    Use `npm run preprocess:data` to generate only the JSON data without HTML.
 
-Reports are saved to the `reports/` folder.
+Reports are saved to the `reports/` folder. The preprocessing step generates
+HTML and JSON reports for several UMLS tables including MRCONSO, MRREL, MRSTY,
+MRDEF, MRSAB, MRSAT, and MRDOC.

--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@
         ['MRCONSO_report.html', 'MRCONSO'],
         ['MRSAB_report.html', 'MRSAB'],
         ['MRREL_report.html', 'MRREL'],
+        ['MRDOC_report.html', 'MRDOC'],
         ['MRSTY_report.html', 'MRSTY'],
         ['MRDEF_report.html', 'MRDEF'],
         ['MRSAT_report.html', 'MRSAT']


### PR DESCRIPTION
## Summary
- support generating MRDOC diff report
- link MRDOC report in the UI
- document MRDOC report generation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d404a77e083279ae5f30c06c0b0cb