### PR TITLE
Add MRRANK report

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
         ['MRREL_report.html', 'MRREL'],
         ['MRSTY_report.html', 'MRSTY'],
         ['MRDEF_report.html', 'MRDEF'],
+        ['MRRANK_report.html', 'MRRANK'],
         ['MRSAT_report.html', 'MRSAT']
       ];
       const rows = [];

--- a/server.js
+++ b/server.js
@@ -264,6 +264,7 @@ app.get('/api/line-count-diff', async (req, res) => {
       else if (/^MRDEF\.RRF$/i.test(base)) link = 'MRDEF_report.html';
       else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
       else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
+      else if (/^MRRANK\.RRF$/i.test(base)) link = 'MRRANK_report.html';
       let status = 'n/a';
       if (link) {
         try {


### PR DESCRIPTION
## Summary
- include MRRANK results in the UI
- generate `MRRANK_report` comparing ranks across releases
- link MRRANK report from line-count comparisons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d407f0e6c8327ba04e38f08e0ecfb