### PR TITLE
Add notes column to line count report

### DIFF
--- a/texts.json
+++ b/texts.json
@@ -3,5 +3,6 @@
   "header": "UMLS Release QA in progress",
   "runPreprocessButton": "Run Reports",
   "note1": "Testing123",
-  "note2": "Testing 345",
-  "note3": ""}
+  "note2": "Testing 345",  "note3": "",
+  "lineCountNotes": {}
+}


### PR DESCRIPTION
## Summary
- store per-file notes in `texts.json`
- preserve existing text values when saving
- show editable notes column in line count diff report

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e70c57964832795b848d1744acb12