### PR TITLE
Add STY source diff reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This project generates HTML reports comparing two UMLS releases.
 Report behavior can be configured by editing `report-config.json` in the project
 root. Currently the only option is:
 
-- `includeStyBreakdowns` – when `true` (default) the MRSTY report will include
-  per-SAB breakdowns for semantic types. Set to `false` to skip these detailed
-  tables.
+- `includeStyBreakdowns` – when `true` (default) the MRSTY report includes
+  per-SAB breakdowns for semantic types and, for each STY/SAB pair, a list of
+  added or removed CUIs. Set to `false` to skip these detailed tables.
 
 When preprocessing runs it stores the last used configuration in
 `reports/config.json`. If the current configuration and release selection match


### PR DESCRIPTION
## Summary
- include new per-SAB diff reports in MRSTY processing
- add function to generate diff HTML and add computeSTYSABCUIMap helper
- save per-SAB diff results under `reports/sty_source_diffs`
- link diff reports from STY breakdown tables
- document the new behavior

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e7dcdb5308327b9227952b166b1a1