### PR TITLE
Fix MRDOC link in line count comparison

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -133,6 +133,7 @@ async function generateLineCountDiff(current, previous) {
     else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
     else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
     else if (/^MRHIER\.RRF$/i.test(base)) link = 'MRHIER_report.html';
+    else if (/^MRDOC\.RRF$/i.test(base)) link = 'MRDOC_report.html';
     result.push({ name, current: cur, previous: prev, diff, percent, link });
   }
 

--- a/server.js
+++ b/server.js
@@ -308,6 +308,7 @@ app.get('/api/line-count-diff', async (req, res) => {
       else if (/^MRREL\.RRF$/i.test(base)) link = 'MRREL_report.html';
       else if (/^MRSAT\.RRF$/i.test(base)) link = 'MRSAT_report.html';
       else if (/^MRHIER\.RRF$/i.test(base)) link = 'MRHIER_report.html';
+      else if (/^MRDOC\.RRF$/i.test(base)) link = 'MRDOC_report.html';
       let status = 'n/a';
       if (link) {
         try {


### PR DESCRIPTION
## Summary
- always include a link from the MRDOC line count diff to the MRDOC report

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e84122d988327a1cb18ed2aa65e28