### PR TITLE
Enable sortable tables

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -38,6 +38,9 @@ table td {
   padding: 6px 10px;
   text-align: left;
 }
+table.sortable th {
+  cursor: pointer;
+}
 tbody tr:nth-child(even) {
   background-color: #fafafa;
 }

--- a/index.html
+++ b/index.html
@@ -165,6 +165,6 @@
     }
 
   </script>
+  <script src="js/sortable.js"></script>
 </body>
-
 </html>

--- a/js/sortable.js
+++ b/js/sortable.js
@@ -1,0 +1,46 @@
+(function(){
+  function makeSortable(table){
+    if(table.dataset.sortable) return;
+    table.dataset.sortable = 'true';
+    const head = table.tHead;
+    if(!head) return;
+    head.addEventListener('click', function(ev){
+      const th = ev.target.closest('th');
+      if(!th) return;
+      const row = th.parentNode;
+      const idx = Array.prototype.indexOf.call(row.children, th);
+      const tbody = table.tBodies[0];
+      if(!tbody) return;
+      const rows = Array.from(tbody.rows);
+      const asc = th.dataset.order !== 'asc';
+      row.querySelectorAll('th').forEach(cell => delete cell.dataset.order);
+      th.dataset.order = asc ? 'asc' : 'desc';
+      rows.sort((a,b)=>{
+        const aText = a.cells[idx].textContent.trim();
+        const bText = b.cells[idx].textContent.trim();
+        const aNum = parseFloat(aText.replace(/[^0-9.-]/g,''));
+        const bNum = parseFloat(bText.replace(/[^0-9.-]/g,''));
+        if(!isNaN(aNum) && !isNaN(bNum)){
+          return asc ? aNum - bNum : bNum - aNum;
+        }
+        return asc ? aText.localeCompare(bText) : bText.localeCompare(aText);
+      });
+      rows.forEach(r=>tbody.appendChild(r));
+    });
+  }
+  function init(){
+    document.querySelectorAll('table').forEach(makeSortable);
+    const obs = new MutationObserver(muts=>{
+      muts.forEach(m=>{
+        m.addedNodes.forEach(n=>{
+          if(n.nodeType!==1) return;
+          if(n.tagName==='TABLE') makeSortable(n);
+          else n.querySelectorAll && n.querySelectorAll('table').forEach(makeSortable);
+        });
+      });
+    });
+    obs.observe(document.body,{childList:true,subtree:true});
+  }
+  if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/preprocess.js
+++ b/preprocess.js
@@ -39,12 +39,12 @@ async function loadReportConfig() {
 
 function wrapHtml(title, body) {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body><h1>${title}</h1>${body}</body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body><h1>${title}</h1>${body}<script src="../js/sortable.js"></script></body></html>`;
 }
 
 function wrapDiffHtml(title, body) {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body><h1>${title}</h1>${body}</body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body><h1>${title}</h1>${body}<script src="../../js/sortable.js"></script></body></html>`;
 }
 
 async function detectReleases() {

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const defaultTexts = {
 
 function wrapHtml(title, body) {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body><h1>${title}</h1>${body}</body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body><h1>${title}</h1>${body}<script src="../js/sortable.js"></script></body></html>`;
 }
 
 function escapeHTML(str) {


### PR DESCRIPTION
## Summary
- add a sortable table script
- include sortable script in generated pages
- load sortable script in the main page
- show pointer cursor on sortable headers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e8434cad08327ad80fb10bc1ae833