### PR TITLE
Add MRFILES report

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ what was used previously, preprocessing is skipped.
 
 Reports are saved to the `reports/` folder. The preprocessing step generates
 HTML and JSON reports for several UMLS tables including MRCONSO, MRREL, MRSTY,
-MRDEF, MRSAB, MRSAT, MRDOC, and MRCOLS.
+MRDEF, MRSAB, MRSAT, MRDOC, MRCOLS, and MRFILES.

--- a/index.html
+++ b/index.html
@@ -146,7 +146,8 @@
         ['MRDEF_report.html', 'MRDEF'],
         ['MRSAT_report.html', 'MRSAT'],
         ['MRHIER_report.html', 'MRHIER'],
-        ['MRCOLS_report.html', 'MRCOLS']
+        ['MRCOLS_report.html', 'MRCOLS'],
+        ['MRFILES_report.html', 'MRFILES']
       ];
       const rows = [];
       let allReady = true;
@@ -167,5 +168,4 @@
 
   </script>
   <script src="js/sortable.js"></script>
-</body>
-</html>
+</body></html>

--- a/server.js
+++ b/server.js
@@ -310,6 +310,7 @@ app.get('/api/line-count-diff', async (req, res) => {
       else if (/^MRHIER\.RRF$/i.test(base)) link = 'MRHIER_report.html';
       else if (/^MRDOC\.RRF$/i.test(base)) link = 'MRDOC_report.html';
       else if (/^MRCOLS\.RRF$/i.test(base)) link = 'MRCOLS_report.html';
+      else if (/^MRFILES\.RRF$/i.test(base)) link = 'MRFILES_report.html';
       let status = 'n/a';
       if (link) {
         try {


### PR DESCRIPTION
## Summary
- generate MRFILES diff report
- expose MRFILES report link in index and preprocess
- map MRFILES to line count diff in server
- document MRFILES report

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e8934677483279ab7429e6c74f230