### PR TITLE
Update MRCOLS diff logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ what was used previously, preprocessing is skipped.
 Reports are saved to the `reports/` folder. The preprocessing step generates
 HTML and JSON reports for several UMLS tables including MRCONSO, MRREL, MRSTY,
 MRDEF, MRSAB, MRSAT, MRDOC, MRCOLS, and MRFILES.
+For the MRCOLS comparison, only the first, second, and seventh fields of each
+record are considered when detecting differences.


### PR DESCRIPTION
## Summary
- limit MRCOLS comparison to first, second, and seventh fields
- document MRCOLS comparison behavior in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e8d04cabc83279dc4831d7e88180e