### PR TITLE
Fix table sorting

### DIFF
--- a/js/sortable.js
+++ b/js/sortable.js
@@ -2,6 +2,7 @@
   function makeSortable(table){
     if(table.dataset.sortable) return;
     table.dataset.sortable = 'true';
+    table.classList.add('sortable');
     const head = table.tHead;
     if(!head) return;
     head.addEventListener('click', function(ev){


### PR DESCRIPTION
## Summary
- ensure sorting styles show up by adding a `sortable` class in the sorting script

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e8d4e3bd0832786c70d7075346f6d