### PR TITLE
Add MRRANK report

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ what was used previously, preprocessing is skipped.
 
 Reports are saved to the `reports/` folder. The preprocessing step generates
 HTML and JSON reports for several UMLS tables including MRCONSO, MRREL, MRSTY,
-MRDEF, MRSAB, MRSAT, MRDOC, MRCOLS, and MRFILES.
+MRDEF, MRSAB, MRSAT, MRDOC, MRCOLS, MRFILES, and MRRANK.
 For the MRCOLS comparison, only the first, second, and seventh fields of each
 record are considered when detecting differences.

--- a/index.html
+++ b/index.html
@@ -147,7 +147,8 @@
         ['MRSAT_report.html', 'MRSAT'],
         ['MRHIER_report.html', 'MRHIER'],
         ['MRCOLS_report.html', 'MRCOLS'],
-        ['MRFILES_report.html', 'MRFILES']
+        ['MRFILES_report.html', 'MRFILES'],
+        ['MRRANK_report.html', 'MRRANK']
       ];
       const rows = [];
       let allReady = true;
@@ -167,5 +168,4 @@
     }
 
   </script>
-  <script src="js/sortable.js"></script>
-</body></html>
+  <script src="js/sortable.js"></script></body></html>

--- a/server.js
+++ b/server.js
@@ -311,6 +311,7 @@ app.get('/api/line-count-diff', async (req, res) => {
       else if (/^MRDOC\.RRF$/i.test(base)) link = 'MRDOC_report.html';
       else if (/^MRCOLS\.RRF$/i.test(base)) link = 'MRCOLS_report.html';
       else if (/^MRFILES\.RRF$/i.test(base)) link = 'MRFILES_report.html';
+      else if (/^MRRANK\.RRF$/i.test(base)) link = 'MRRANK_report.html';
       let status = 'n/a';
       if (link) {
         try {


### PR DESCRIPTION
## Summary
- generate MRRANK report comparing term type order
- list MRRANK report in UI and server link mapping
- document new report

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e8fc9090c8327a60765b414a3c6ee