### PR TITLE
Fix anchor offsets for sticky nav

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -87,3 +87,8 @@ tbody tr:hover {
 .sticky-links a {
   margin-right: 10px;
 }
+
+/* Offset anchors for sticky headings */
+h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
+  scroll-margin-top: 2.5em;
+}


### PR DESCRIPTION
## Summary
- add CSS `scroll-margin-top` to all heading levels

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e98c2bd3c83278f2fd06daab3e6b9