### PR TITLE
Enable smooth scrolling when navigating reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,11 @@
           try {
             const doc = frame.contentWindow.document;
             frame.style.height = doc.documentElement.scrollHeight + 'px';
+            doc.addEventListener('click', ev => {
+              if (ev.target.closest('a')) {
+                document.getElementById('line-results').scrollIntoView({ behavior: 'smooth' });
+              }
+            });
           } catch {}
         });
         return true;
@@ -151,5 +156,4 @@
         results.innerHTML = '<p>No reports available.</p>';
         return false;
       }
-    }
-  </script>  <script src="js/sortable.js"></script></body></html>
+    }  </script>  <script src="js/sortable.js"></script></body></html>


### PR DESCRIPTION
## Summary
- scroll to the top of the report section whenever any link is clicked inside a report iframe

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e9ba15488832788637ae32dc36d15