### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -107,3 +107,17 @@ h5[id],
 h6[id] {
   scroll-margin-top: 2.5em;
 }
+
+nav.breadcrumbs {
+  font-size: 0.9em;
+  margin: 10px 0;
+}
+
+nav.breadcrumbs a {
+  color: #0645ad;
+  text-decoration: none;
+  margin-right: 6px;
+}
+
+nav.breadcrumbs a:hover {
+  text-decoration: underline;}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 
 <body>
   <div class="container">
+    <nav class="breadcrumbs"><a href="index.html">Home</a></nav>
     <h1 id="page-title" class="editable">UMLS Release QA</h1>
     <div id="status"></div>
     <p id="note1" class="editable note"></p>

--- a/preprocess.js
+++ b/preprocess.js
@@ -39,12 +39,14 @@ async function loadReportConfig() {
 
 function wrapHtml(title, body) {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body><h1>${title}</h1>${body}<script src="../js/sortable.js"></script></body></html>`;
+  const crumbs = '<nav class="breadcrumbs"><a href="../index.html">Home</a> &gt; <a href="line-count-diff.html">Line Count Comparison</a></nav>';
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${body}<script src="../js/sortable.js"></script></body></html>`;
 }
 
 function wrapDiffHtml(title, body) {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body><h1>${title}</h1>${body}<script src="../../js/sortable.js"></script></body></html>`;
+  const crumbs = '<nav class="breadcrumbs"><a href="../../index.html">Home</a> &gt; <a href="../line-count-diff.html">Line Count Comparison</a></nav>';
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${body}<script src="../../js/sortable.js"></script></body></html>`;
 }
 
 async function detectReleases() {
@@ -1183,7 +1185,9 @@ async function generateMRRANKReport(current, previous) {
     MRDOC: hashOf(generateMRDOCReport.toString()),
     MRCOLS: hashOf(generateMRCOLSReport.toString()),
     MRFILES: hashOf(generateMRFILESReport.toString()),
-    MRRANK: hashOf(generateMRRANKReport.toString())
+    MRRANK: hashOf(generateMRRANKReport.toString()),
+    wrapHtml: hashOf(wrapHtml.toString()),
+    wrapDiffHtml: hashOf(wrapDiffHtml.toString())
   };
 
   let lastConfig = null;

--- a/server.js
+++ b/server.js
@@ -19,7 +19,8 @@ const defaultTexts = {
 
 function wrapHtml(title, body) {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body><h1>${title}</h1>${body}<script src="../js/sortable.js"></script></body></html>`;
+  const crumbs = '<nav class="breadcrumbs"><a href="../index.html">Home</a> &gt; <a href="line-count-diff.html">Line Count Comparison</a></nav>';
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${body}<script src="../js/sortable.js"></script></body></html>`;
 }
 
 function escapeHTML(str) {


### PR DESCRIPTION
## Summary
- add breadcrumb navigation style
- show breadcrumbs on the main index page
- include breadcrumbs in all generated HTML via wrapHtml helpers
- ensure preprocess runs when HTML templates change

## Testing
- `npm test` *(fails: no test specified)*
- `npm run preprocess:data` *(fails: Need at least two releases in releases/)*

------
https://chatgpt.com/codex/tasks/task_e_686eb96203348327b8b988b48b893df0