### PR TITLE
Add percent change to MRFILES report

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ The preprocessing step generates HTML and JSON reports for several UMLS tables
 including MRCONSO, MRREL, MRSTY, MRDEF, MRSAB, MRSAT, MRDOC, MRCOLS, MRFILES,
 and MRRANK.
 The MRFILES report lists added, dropped, and size-changed files in sortable
-tables for easier review.
+tables for easier review. Size changes now include a percentage column to show
+relative growth or shrinkage.

--- a/preprocess.js
+++ b/preprocess.js
@@ -1159,7 +1159,9 @@ async function generateMRFILESReport(current, previous) {
     } else {
       const prevSize = prevMap.get(file);
       if (prevSize !== size) {
-        changed.push({ file, previous: prevSize, current: size });
+        const diff = size - prevSize;
+        const percent = prevSize === 0 ? Infinity : diff / prevSize * 100;
+        changed.push({ file, previous: prevSize, current: size, diff, percent });
       }
     }
   }
@@ -1194,10 +1196,10 @@ async function generateMRFILESReport(current, previous) {
     }
     if (changed.length) {
       html += `<h4>Size Changes (${changed.length})</h4>`;
-      html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Diff</th></tr></thead><tbody>';
+      html += '<table><thead><tr><th>File</th><th>Previous</th><th>Current</th><th>Diff</th><th>%</th></tr></thead><tbody>';
       for (const c of changed) {
-        const diff = c.current - c.previous;
-        html += `<tr><td>${escapeHTML(c.file)}</td><td>${c.previous}</td><td>${c.current}</td><td>${diff}</td></tr>`;
+        const pct = isFinite(c.percent) ? c.percent.toFixed(2) : 'inf';
+        html += `<tr><td>${escapeHTML(c.file)}</td><td>${c.previous}</td><td>${c.current}</td><td>${c.diff}</td><td>${pct}</td></tr>`;
       }
       html += '</tbody></table>';
     }


### PR DESCRIPTION
## Summary
- display percent change in MRFILES size change table
- document percent column in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ee456f9ec8327bc950f00a9c7adb2