### PR TITLE
Fix streaming updates for Run Reports

### DIFF
--- a/server.js
+++ b/server.js
@@ -212,6 +212,8 @@ app.get('/api/preprocess-stream', async (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+  res.write(': connected\n\n');
 
   const { current, previous } = await detectReleases();
   if (current && previous) {


### PR DESCRIPTION
## Summary
- flush headers and send initial SSE comment in `/api/preprocess-stream`

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_686fd28cadc0832785c8f12ece797062