### PR TITLE
Improve MRCOLS report formatting

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -1121,10 +1121,28 @@ async function generateMRCOLSReport(current, previous) {
     html += '<p>No differences found.</p>';
   } else {
     if (added.length) {
-      html += `<h4>Added (${added.length})</h4><pre>${added.map(escapeHTML).join('\n')}</pre>`;
+      html += `<h4>Added (${added.length})</h4>`;
+      html += '<table><thead><tr><th>File</th><th>Column</th><th>Type</th></tr></thead><tbody>';
+      for (const row of added) {
+        const parts = row.split('|');
+        const file = parts[0] || '';
+        const col = parts[1] || '';
+        const type = parts[2] || '';
+        html += `<tr><td>${escapeHTML(file)}</td><td>${escapeHTML(col)}</td><td>${escapeHTML(type)}</td></tr>`;
+      }
+      html += '</tbody></table>';
     }
     if (removed.length) {
-      html += `<h4>Removed (${removed.length})</h4><pre>${removed.map(escapeHTML).join('\n')}</pre>`;
+      html += `<h4>Removed (${removed.length})</h4>`;
+      html += '<table><thead><tr><th>File</th><th>Column</th><th>Type</th></tr></thead><tbody>';
+      for (const row of removed) {
+        const parts = row.split('|');
+        const file = parts[0] || '';
+        const col = parts[1] || '';
+        const type = parts[2] || '';
+        html += `<tr><td>${escapeHTML(file)}</td><td>${escapeHTML(col)}</td><td>${escapeHTML(type)}</td></tr>`;
+      }
+      html += '</tbody></table>';
     }
   }
   if (generateHtml) {


### PR DESCRIPTION
## Summary
- format MRCOLS report output using HTML tables instead of `<pre>` blocks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687513f715c48327bae30ffa6fb0d6e9