### PR TITLE
Fix MRREL memory usage

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -904,6 +904,42 @@ async function gatherMRRELRows(file, keys) {
   return rowsMap;
 }
 
+// Gather rows for a single SAB|REL|RELA key in MRREL
+async function gatherMRRELRowsForKey(file, key) {
+  const rows = [];
+  const [expectSab, expectRel, expectRela] = key.split('|');
+  try {
+    const rl = readline.createInterface({ input: fs.createReadStream(file) });
+    let i = 0;
+    for await (const line of rl) {
+      i++;
+      const parts = line.split('|');
+      if (parts.length < 11) continue;
+      const sab = parts[10] || 'MISSING';
+      const rel = parts[3] || 'MISSING';
+      const rela = parts[7] || 'MISSING';
+      if (sab === expectSab && rel === expectRel && rela === expectRela) {
+        rows.push({
+          RUI: parts[8],
+          CUI1: parts[0],
+          AUI1: parts[1],
+          REL: rel,
+          CUI2: parts[4],
+          AUI2: parts[5],
+          SAB: sab,
+          RELA: rela
+        });
+      }
+      if (i % 100000 === 0) {
+        console.log(`  Processed ${i} lines of ${path.basename(file)}...`);
+      }
+    }
+  } catch {
+    return [];
+  }
+  return rows;
+}
+
 async function collectConsoNames(file, auis, cuis) {
   const byAUI = new Map();
   const byCUI = new Map();
@@ -979,12 +1015,7 @@ async function generateMRRELReport(current, previous) {
   const prevCounts = await readCountsByIndices(previousFile, [10, 3, 7]);
   await fsp.mkdir(diffsDir, { recursive: true });
   const summary = [];
-  const diffKeys = new Set();
-  const diffEntries = [];
-  const curAUIs = new Set();
-  const curCUIs = new Set();
-  const prevAUIs = new Set();
-  const prevCUIs = new Set();
+  const diffKeys = [];
   const keys = new Set([...baseCounts.keys(), ...prevCounts.keys()]);
   for (const key of keys) {
     const currentCount = baseCounts.get(key) || 0;
@@ -993,7 +1024,7 @@ async function generateMRRELReport(current, previous) {
     const pct = previousCount === 0 ? Infinity : (diff / previousCount * 100);
     const [sab, rel, rela] = key.split('|');
     const entry = { SAB: sab, REL: rel, RELA: rela, Previous: previousCount, Current: currentCount, Difference: diff, Percent: pct, link: '' };
-    if (Math.abs(pct) >= 5) diffKeys.add(key);
+    if (Math.abs(pct) >= 5) diffKeys.push(key);
     summary.push(entry);
   }
 
@@ -1003,34 +1034,31 @@ async function generateMRRELReport(current, previous) {
     return a.RELA.localeCompare(b.RELA);
   });
 
-  if (diffKeys.size) {
-    const curRowsMap = await gatherMRRELRows(currentFile, diffKeys);
-    const prevRowsMap = await gatherMRRELRows(previousFile, diffKeys);
-
+  if (diffKeys.length) {
     for (const entry of summary) {
       const key = `${entry.SAB}|${entry.REL}|${entry.RELA}`;
-      if (!diffKeys.has(key)) continue;
-      const baseRows = curRowsMap.get(key) || [];
-      const prevRows = prevRowsMap.get(key) || [];
+      if (!diffKeys.includes(key)) continue;
+      const baseRows = await gatherMRRELRowsForKey(currentFile, key);
+      const prevRows = await gatherMRRELRowsForKey(previousFile, key);
       const diffData = buildMRRELDiffData(key, baseRows, prevRows);
-      if (diffData) {
-        for (const r of diffData.added) {
-          if (r.AUI1) curAUIs.add(r.AUI1); else curCUIs.add(r.CUI1);
-          if (r.AUI2) curAUIs.add(r.AUI2); else curCUIs.add(r.CUI2);
-        }
-        for (const r of diffData.dropped) {
-          if (r.AUI1) prevAUIs.add(r.AUI1); else prevCUIs.add(r.CUI1);
-          if (r.AUI2) prevAUIs.add(r.AUI2); else prevCUIs.add(r.CUI2);
-        }
-        const safe = key.replace(/[^A-Za-z0-9_-]/g, '_');
-        diffEntries.push({ entry, key, diffData, safe });
+      if (!diffData) continue;
+
+      const curAUIs = new Set();
+      const curCUIs = new Set();
+      const prevAUIs = new Set();
+      const prevCUIs = new Set();
+      for (const r of diffData.added) {
+        if (r.AUI1) curAUIs.add(r.AUI1); else curCUIs.add(r.CUI1);
+        if (r.AUI2) curAUIs.add(r.AUI2); else curCUIs.add(r.CUI2);
       }
-    }
+      for (const r of diffData.dropped) {
+        if (r.AUI1) prevAUIs.add(r.AUI1); else prevCUIs.add(r.CUI1);
+        if (r.AUI2) prevAUIs.add(r.AUI2); else prevCUIs.add(r.CUI2);
+      }
 
-    const curNames = await collectConsoNames(path.join(releasesDir, current, 'META', 'MRCONSO.RRF'), curAUIs, curCUIs);
-    const prevNames = await collectConsoNames(path.join(releasesDir, previous, 'META', 'MRCONSO.RRF'), prevAUIs, prevCUIs);
+      const curNames = await collectConsoNames(path.join(releasesDir, current, 'META', 'MRCONSO.RRF'), curAUIs, curCUIs);
+      const prevNames = await collectConsoNames(path.join(releasesDir, previous, 'META', 'MRCONSO.RRF'), prevAUIs, prevCUIs);
 
-    for (const { entry, diffData, safe } of diffEntries) {
       for (const r of diffData.added) {
         r.STR1 = curNames.byAUI.get(r.AUI1) || curNames.byCUI.get(r.CUI1) || '';
         r.STR2 = curNames.byAUI.get(r.AUI2) || curNames.byCUI.get(r.CUI2) || '';
@@ -1039,6 +1067,8 @@ async function generateMRRELReport(current, previous) {
         r.STR1 = prevNames.byAUI.get(r.AUI1) || prevNames.byCUI.get(r.CUI1) || '';
         r.STR2 = prevNames.byAUI.get(r.AUI2) || prevNames.byCUI.get(r.CUI2) || '';
       }
+
+      const safe = key.replace(/[^A-Za-z0-9_-]/g, '_');
       const fileName = `MRREL_${safe}_diff.json`;
       await fsp.writeFile(path.join(diffsDir, fileName), JSON.stringify(diffData, null, 2));
       if (generateHtml) {


### PR DESCRIPTION
## Summary
- avoid accumulating MRREL diff data for all keys at once
- add helper to gather rows for a single MRREL key

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check preprocess.js`

------
https://chatgpt.com/codex/tasks/task_e_6877f498f5ec8327974938077e342aab