### PR TITLE
Allow rerunning reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project generates HTML reports comparing two UMLS releases.
 
 1. Place at least two release directories under `releases/`.
 2. Run `npm run preprocess` to generate reports with HTML output.
+   Add `-- --force` to rerun reports even if no logic changes were detected.
 
 Reports are saved to a versioned subfolder under `reports/` named after the
 current release (for example `reports/2025AA/`).

--- a/preprocess.js
+++ b/preprocess.js
@@ -24,6 +24,10 @@ let configFile = path.join(reportsDir, 'config.json');
 const userConfigPath = path.join(__dirname, 'report-config.json');
 // If --data-only is passed, skip generating HTML output
 const generateHtml = !process.argv.includes('--data-only');
+// If --force is passed, do not skip regeneration when configuration and logic
+// have not changed. This allows the UI "Re-run Report" button to always
+// regenerate reports when requested.
+const forceRun = process.argv.includes('--force');
 
 function hashOf(str) {
   return crypto.createHash('sha256').update(str).digest('hex');
@@ -1359,7 +1363,7 @@ async function generateMRRANKReport(current, previous) {
   const sameConfig = lastConfig && JSON.stringify(lastConfig.reportConfig || {}) === JSON.stringify(reportConfig);
   const lastHashes = (lastConfig && lastConfig.logicHashes) || {};
   const sameHashes = JSON.stringify(lastHashes) === JSON.stringify(currentHashes);
-  if (sameReleases && sameConfig && sameHashes) {
+  if (!forceRun && sameReleases && sameConfig && sameHashes) {
     console.log('Report configuration and logic unchanged. Skipping regeneration.');
     return;
   }

--- a/server.js
+++ b/server.js
@@ -247,7 +247,8 @@ app.post('/api/preprocess', async (req, res) => {
     }
   }
   const script = path.join(__dirname, 'preprocess.js');
-  exec(`node --max-old-space-size=8192 ${script}`, { cwd: __dirname }, (error, stdout, stderr) => {
+  const cmd = `node --max-old-space-size=8192 ${script}${force ? ' --force' : ''}`;
+  exec(cmd, { cwd: __dirname }, (error, stdout, stderr) => {
     if (error) {
       // Detect the common "not enough releases" message and return a 400
       const msg = (stderr || error.message || '').trim();
@@ -295,7 +296,9 @@ app.get('/api/preprocess-stream', async (req, res) => {
   }
 
   const script = path.join(__dirname, 'preprocess.js');
-  const child = spawn('node', ['--max-old-space-size=8192', script], { cwd: __dirname });
+  const args = ['--max-old-space-size=8192', script];
+  if (force) args.push('--force');
+  const child = spawn('node', args, { cwd: __dirname });
 
   child.stdout.on('data', chunk => {
     const data = chunk.toString().trim();


### PR DESCRIPTION
## Summary
- add `--force` option to preprocessing script
- forward the `force` query parameter to use `--force`
- update README with instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node preprocess.js --force --data-only` *(fails: Need at least two releases in releases/)*

------
https://chatgpt.com/codex/tasks/task_e_6878111be48c8327b596812d76190376