### PR TITLE
Add single report rerun support

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -28,6 +28,8 @@ const generateHtml = !process.argv.includes('--data-only');
 // have not changed. This allows the UI "Re-run Report" button to always
 // regenerate reports when requested.
 const forceRun = process.argv.includes('--force');
+const reportArg = process.argv.find(a => a.startsWith('--report='));
+const singleReport = reportArg ? reportArg.slice('--report='.length) : null;
 
 function hashOf(str) {
   return crypto.createHash('sha256').update(str).digest('hex');
@@ -42,15 +44,28 @@ async function loadReportConfig() {
   }
 }
 
-function wrapHtml(title, body) {
+function wrapHtml(title, body, reportKey = '') {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
   const crumbs = '<nav class="breadcrumbs"><a href="line-count-diff.html">Line Count Comparison</a></nav>';
   const button = '<button id="rerun-report">Re-run Report</button><div id="rerun-status"></div>';
-  const script = `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true);}else{location.reload();}});</script>`;
+  const script = reportKey ?
+    `<script>
+      document.getElementById('rerun-report').addEventListener('click', () => {
+        const out = document.getElementById('rerun-status');
+        out.innerHTML = '';
+        const append = t => { const pre = document.createElement('pre'); pre.textContent = t; out.appendChild(pre); };
+        append('Running report...');
+        const es = new EventSource('/api/run-report-stream?report=${reportKey}');
+        es.onmessage = e => append(e.data);
+        es.addEventListener('done', () => { es.close(); append('Done.'); location.reload(); });
+        es.onerror = () => { es.close(); append('Error running report.'); };
+      });
+    </script>` :
+    `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true);}else{location.reload();}});</script>`;
   return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}${body}<script src="../../js/sortable.js"></script>${script}</body></html>`;
 }
 
-function wrapDiffHtml(title, body, parentTitle = '', parentLink = '') {
+function wrapDiffHtml(title, body, parentTitle = '', parentLink = '', reportKey = '') {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
   let crumbs = '<nav class="breadcrumbs"><a href="../line-count-diff.html">Line Count Comparison</a>';
   if (parentTitle && parentLink) {
@@ -58,7 +73,20 @@ function wrapDiffHtml(title, body, parentTitle = '', parentLink = '') {
   }
   crumbs += '</nav>';
   const button = '<button id="rerun-report">Re-run Report</button><div id="rerun-status"></div>';
-  const script = `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true);}else{location.reload();}});</script>`;
+  const script = reportKey ?
+    `<script>
+      document.getElementById('rerun-report').addEventListener('click', () => {
+        const out = document.getElementById('rerun-status');
+        out.innerHTML = '';
+        const append = t => { const pre = document.createElement('pre'); pre.textContent = t; out.appendChild(pre); };
+        append('Running report...');
+        const es = new EventSource('/api/run-report-stream?report=${reportKey}');
+        es.onmessage = e => append(e.data);
+        es.addEventListener('done', () => { es.close(); append('Done.'); location.reload(); });
+        es.onerror = () => { es.close(); append('Error running report.'); };
+      });
+    </script>` :
+    `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true);}else{location.reload();}});</script>`;
   return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}${body}<script src="../../../js/sortable.js"></script>${script}</body></html>`;
 }
 
@@ -197,7 +225,7 @@ async function generateLineCountDiff(current, previous) {
     }
     load();
   </script>`;
-  const wrapped = wrapHtml('Line Count Comparison', html);
+  const wrapped = wrapHtml('Line Count Comparison', html, 'line-count-diff');
   if (generateHtml) {
     await fsp.writeFile(path.join(reportsDir, 'line-count-diff.html'), wrapped);
   }
@@ -399,7 +427,8 @@ function diffDataToHtml(data) {
     `${data.sab} ${data.tty} Differences`,
     html,
     'MRCONSO Report',
-    '../MRCONSO_report.html'
+    '../MRCONSO_report.html',
+    'MRCONSO'
   );
 }
 
@@ -428,7 +457,8 @@ function stySabDiffToHtml(data) {
     `${data.sty} ${data.sab} Changes`,
     html,
     'MRSTY Report',
-    '../MRSTY_report.html'
+    '../MRSTY_report.html',
+    'MRSTY'
   );
 }
 
@@ -505,7 +535,7 @@ async function generateSABDiff(current, previous) {
     html += `<tr><td>${row.SAB}</td><td>${row.TTY}</td><td>${row.Previous}</td><td>${row.Current}</td><td class="${diffClass}">${row.Difference}</td><td>${pct}</td><td>${linkCell}</td></tr>`;
   }
   html += '</tbody></table>';
-  const wrapped = wrapHtml('MRCONSO Report', html);
+  const wrapped = wrapHtml('MRCONSO Report', html, 'MRCONSO');
   if (generateHtml) {
     await fsp.writeFile(path.join(reportsDir, 'MRCONSO_report.html'), wrapped);
   }
@@ -706,7 +736,8 @@ async function generateSTYReports(current, previous, reportConfig = {}) {
               `${sty} by SAB`,
               html,
               'MRSTY Report',
-              '../MRSTY_report.html'
+              '../MRSTY_report.html',
+              'MRSTY'
             )
           );
         }
@@ -756,7 +787,7 @@ async function generateSTYReports(current, previous, reportConfig = {}) {
   html += '</tbody></table>';
   if (generateHtml) {
       const title = `MRSTY Report (${current} vs ${previous})`;
-      await fsp.writeFile(path.join(reportsDir, 'MRSTY_report.html'), wrapHtml(title, html));
+      await fsp.writeFile(path.join(reportsDir, 'MRSTY_report.html'), wrapHtml(title, html, 'MRSTY'));
   }
   console.log('  STY reports complete.');
 }
@@ -786,7 +817,7 @@ async function generateCountReport(current, previous, fileName, indices, tableNa
     html += `<tr><td>${escapeHTML(row.Key)}</td><td>${row.Previous}</td><td>${row.Current}</td><td class="${diffClass}">${row.Difference}</td><td>${pctTxt}</td></tr>`;
   }
   html += '</tbody></table>';
-  const wrapped = wrapHtml(`${tableName} Report (${current} vs ${previous})`, html);
+  const wrapped = wrapHtml(`${tableName} Report (${current} vs ${previous})`, html, tableName);
   if (generateHtml) {
     await fsp.writeFile(path.join(reportsDir, `${tableName}_report.html`), wrapped);
   }
@@ -864,7 +895,7 @@ async function generateMRSABChangeReport(current, previous) {
   if (!added.length && !dropped.length && !addedRows.length && !removedRows.length) {
     html += '<p>No MRSAB changes.</p>';
   }
-  const wrapped = wrapHtml('MRSAB Report', html);
+  const wrapped = wrapHtml('MRSAB Report', html, 'MRSAB');
   if (generateHtml) {
     await fsp.writeFile(path.join(reportsDir, 'MRSAB_report.html'), wrapped);
   }
@@ -973,7 +1004,8 @@ function mrrelDiffToHtml(data) {
     `${data.sab} ${data.rel} ${data.rela} Differences`,
     html,
     'MRREL Report',
-    '../MRREL_report.html'
+    '../MRREL_report.html',
+    'MRREL'
   );
 }
 
@@ -1092,7 +1124,7 @@ async function generateMRRELReport(current, previous) {
   }
   html += '</tbody></table>';
   const title = `MRREL Report (${current} vs ${previous})`;
-  const wrapped = wrapHtml(title, html);
+  const wrapped = wrapHtml(title, html, 'MRREL');
   if (generateHtml) {
     await fsp.writeFile(path.join(reportsDir, 'MRREL_report.html'), wrapped);
   }
@@ -1122,7 +1154,7 @@ async function generateMRDOCReport(current, previous) {
     }
   }
   if (generateHtml) {
-    await fsp.writeFile(path.join(reportsDir, 'MRDOC_report.html'), wrapHtml('MRDOC Report', html));
+    await fsp.writeFile(path.join(reportsDir, 'MRDOC_report.html'), wrapHtml('MRDOC Report', html, 'MRDOC'));
   }
 }
 
@@ -1168,7 +1200,7 @@ async function generateMRCOLSReport(current, previous) {
     }
   }
   if (generateHtml) {
-    await fsp.writeFile(path.join(reportsDir, 'MRCOLS_report.html'), wrapHtml('MRCOLS Report', html));
+    await fsp.writeFile(path.join(reportsDir, 'MRCOLS_report.html'), wrapHtml('MRCOLS Report', html, 'MRCOLS'));
   }
 }
 
@@ -1255,7 +1287,7 @@ async function generateMRFILESReport(current, previous) {
     }
   }
   if (generateHtml) {
-    await fsp.writeFile(path.join(reportsDir, 'MRFILES_report.html'), wrapHtml('MRFILES Report', html));
+    await fsp.writeFile(path.join(reportsDir, 'MRFILES_report.html'), wrapHtml('MRFILES Report', html, 'MRFILES'));
   }
 }
 
@@ -1317,7 +1349,7 @@ async function generateMRRANKReport(current, previous) {
     html += '</tbody></table>';
   }
   if (generateHtml) {
-    await fsp.writeFile(path.join(reportsDir, 'MRRANK_report.html'), wrapHtml('MRRANK Report', html));
+    await fsp.writeFile(path.join(reportsDir, 'MRRANK_report.html'), wrapHtml('MRRANK Report', html, 'MRRANK'));
   }
 }
 
@@ -1337,6 +1369,56 @@ async function generateMRRANKReport(current, previous) {
   configFile = path.join(reportsDir, 'config.json');
 
   const reportConfig = await loadReportConfig();
+
+  if (singleReport) {
+    try {
+      switch (singleReport) {
+        case 'line-count-diff':
+          await generateLineCountDiff(current, previous);
+          break;
+        case 'MRCONSO':
+          await generateSABDiff(current, previous);
+          break;
+        case 'MRSTY':
+          await generateSTYReports(current, previous, reportConfig);
+          break;
+        case 'MRSAB':
+          await generateMRSABChangeReport(current, previous);
+          break;
+        case 'MRDEF':
+          await generateCountReport(current, previous, 'MRDEF.RRF', [4], 'MRDEF');
+          break;
+        case 'MRSAT':
+          await generateCountReport(current, previous, 'MRSAT.RRF', [9], 'MRSAT');
+          break;
+        case 'MRHIER':
+          await generateCountReport(current, previous, 'MRHIER.RRF', [4], 'MRHIER');
+          break;
+        case 'MRREL':
+          await generateMRRELReport(current, previous);
+          break;
+        case 'MRDOC':
+          await generateMRDOCReport(current, previous);
+          break;
+        case 'MRCOLS':
+          await generateMRCOLSReport(current, previous);
+          break;
+        case 'MRFILES':
+          await generateMRFILESReport(current, previous);
+          break;
+        case 'MRRANK':
+          await generateMRRANKReport(current, previous);
+          break;
+        default:
+          console.error('Unknown report:', singleReport);
+          process.exit(1);
+      }
+    } catch (err) {
+      console.error('Error generating report:', err.message);
+      process.exit(1);
+    }
+    return;
+  }
 
   const currentHashes = {
     lineCountDiff: hashOf(generateLineCountDiff.toString()),


### PR DESCRIPTION
## Summary
- allow preprocessing script to run a single report using `--report`
- embed a progress streaming script in generated reports
- expose `/api/run-report-stream` to spawn a single report

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node preprocess.js --report=MRDOC --data-only` *(fails: Need at least two releases in releases/)*
- `node preprocess.js --report=MRCONSO --data-only` *(fails: Need at least two releases in releases/)*

------
https://chatgpt.com/codex/tasks/task_e_68790b76a1b083278300f14a1fdf37fd