### PR TITLE
Sort MRDEF counts by SAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and MRRANK.
 The MRFILES report lists added, dropped, and size-changed files in sortable
 tables for easier review. Size changes now include a percentage column to show
 relative growth or shrinkage.
+Counts in the MRDEF report are sorted alphabetically by SAB.
 
 ### Viewing Reports
 

--- a/preprocess.js
+++ b/preprocess.js
@@ -775,6 +775,7 @@ async function generateCountReport(current, previous, fileName, indices, tableNa
     const pct = previousCount === 0 ? Infinity : (diff / previousCount * 100);
     summary.push({ Key: key, Previous: previousCount, Current: currentCount, Difference: diff, Percent: pct });
   }
+  summary.sort((a, b) => a.Key.localeCompare(b.Key));
   const jsonName = `${tableName}_report.json`;
   await fsp.writeFile(path.join(reportsDir, jsonName), JSON.stringify({ current, previous, summary }, null, 2));
 


### PR DESCRIPTION
## Summary
- sort entries in `generateCountReport` so MRDEF counts are ordered by SAB
- document MRDEF ordering in the README

## Testing
- `node --version`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68790cd9bddc83279d9fd2783a1d0280