### PR TITLE
Handle rerun progress display

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,12 @@
 
     // Automatically check for finished reports when running preprocessing
 
-    function runReports(force = false) {
-      const output = document.getElementById('preprocess-results');
+    function runReports(force = false, targetEl) {
+      const output = targetEl || document.getElementById('preprocess-results');
+      const results = document.getElementById('line-results');
+      if (output.ownerDocument === document) {
+        results.innerHTML = '';
+      }
       const append = (text) => {
         const pre = document.createElement('pre');
         pre.textContent = text;

--- a/preprocess.js
+++ b/preprocess.js
@@ -52,6 +52,8 @@ function wrapHtml(title, body, reportKey = '') {
     `<script>
       document.getElementById('rerun-report').addEventListener('click', () => {
         const out = document.getElementById('rerun-status');
+        const content = document.getElementById('report-content');
+        if (content) content.innerHTML = '';
         out.innerHTML = '';
         const append = t => { const pre = document.createElement('pre'); pre.textContent = t; out.appendChild(pre); };
         append('Running report...');
@@ -61,8 +63,8 @@ function wrapHtml(title, body, reportKey = '') {
         es.onerror = () => { es.close(); append('Error running report.'); };
       });
     </script>` :
-    `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true);}else{location.reload();}});</script>`;
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}${body}<script src="../../js/sortable.js"></script>${script}</body></html>`;
+    `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true, document.getElementById('rerun-status'));}else{location.reload();}});</script>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}<div id="report-content">${body}</div><script src="../../js/sortable.js"></script>${script}</body></html>`;
 }
 
 function wrapDiffHtml(title, body, parentTitle = '', parentLink = '', reportKey = '') {
@@ -77,6 +79,8 @@ function wrapDiffHtml(title, body, parentTitle = '', parentLink = '', reportKey 
     `<script>
       document.getElementById('rerun-report').addEventListener('click', () => {
         const out = document.getElementById('rerun-status');
+        const content = document.getElementById('report-content');
+        if (content) content.innerHTML = '';
         out.innerHTML = '';
         const append = t => { const pre = document.createElement('pre'); pre.textContent = t; out.appendChild(pre); };
         append('Running report...');
@@ -86,8 +90,8 @@ function wrapDiffHtml(title, body, parentTitle = '', parentLink = '', reportKey 
         es.onerror = () => { es.close(); append('Error running report.'); };
       });
     </script>` :
-    `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true);}else{location.reload();}});</script>`;
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}${body}<script src="../../../js/sortable.js"></script>${script}</body></html>`;
+    `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true, document.getElementById('rerun-status'));}else{location.reload();}});</script>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}<div id="report-content">${body}</div><script src="../../../js/sortable.js"></script>${script}</body></html>`;
 }
 
 async function detectReleases() {

--- a/server.js
+++ b/server.js
@@ -21,8 +21,8 @@ function wrapHtml(title, body) {
   const style = '<style>table{width:100%;border-collapse:collapse;border:1px solid #ccc;margin-top:10px;font-size:0.9em}table th,table td{border:1px solid #ccc;padding:6px 10px;text-align:left}thead{background-color:#f2f2f2}</style>';
   const crumbs = '<nav class="breadcrumbs"><a href="line-count-diff.html">Line Count Comparison</a></nav>';
   const button = '<button id="rerun-report">Re-run Report</button><div id="rerun-status"></div>';
-  const script = `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true);}else{location.reload();}});</script>`;
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}${body}<script src="../../js/sortable.js"></script>${script}</body></html>`;
+  const script = `<script>document.getElementById('rerun-report').addEventListener('click',()=>{if(parent&&parent.runReports){parent.runReports(true, document.getElementById('rerun-status'));}else{location.reload();}});</script>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>${title}</title><link rel="stylesheet" href="../../css/styles.css">${style}</head><body>${crumbs}<h1>${title}</h1>${button}<div id="report-content">${body}</div><script src="../../js/sortable.js"></script>${script}</body></html>`;
 }
 
 function escapeHTML(str) {


### PR DESCRIPTION
## Summary
- update report wrapper HTML and script so rerun progress appears under the rerun button
- allow `runReports` to accept a target element and clear the previous report

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687911c8f2ec832798333b71b78aa47c