### PR TITLE
Fix back navigation duplicate history

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,8 +96,7 @@
             <p>Previous release: <strong>${previous}</strong></p>
             <p style="color:green">Releases are ready for comparison.</p>
           `;
-          loadReports(undefined, true);
-          await loadReports();
+          await loadReports(undefined, true);
         } else {
           status.innerHTML = `
             <p style="color:red">Could not find at least two release folders.</p>


### PR DESCRIPTION
## Summary
- prevent duplicate history entries when checking releases

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a54991c1c8327ad3475df955f21d4