### PR TITLE
Fix back button history

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,10 @@
       } else {
         url.searchParams.delete('report');
       }
+
+      // Avoid pushing duplicate history entries when the URL hasn't changed
+      if (url.href === window.location.href) return;
+
       if (replace) {
         history.replaceState(null, '', url);
       } else {


### PR DESCRIPTION
## Summary
- avoid pushing duplicate history entries for reports

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a5ac438cc8327b487b6f2c21dc8ca