### PR TITLE
Fix vertical scrollbar in line count diff report

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,7 @@
         frame.id = 'report-frame';
         frame.style.width = '100%';
         frame.style.border = 'none';
+        frame.style.overflow = 'hidden';
         frame.srcdoc = html;
         results.innerHTML = '';
         results.appendChild(frame);


### PR DESCRIPTION
## Summary
- hide the scroll bar on the report iframe

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a5c24b6c08327bf15fdb81954086e