### PR TITLE
Filter STY breakdown to contributing sources

### DIFF
--- a/preprocess.js
+++ b/preprocess.js
@@ -838,7 +838,7 @@ async function generateSTYReports(current, previous, reportConfig = {}) {
         const p = prevSet.size;
         const d = c - p;
         let link2 = '';
-        if (d !== 0) {
+        if (d !== 0 && Math.sign(d) === Math.sign(diff)) {
           const pp = p === 0 ? Infinity : (d / p * 100);
           const added = [...curSet].filter(x => !prevSet.has(x));
           const removed = [...prevSet].filter(x => !curSet.has(x));


### PR DESCRIPTION
## Summary
- show STY breakdown sources only when their CUI change direction matches the overall semantic type change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af4c51fc508327876d78b8353dde3d